### PR TITLE
Add support for periodic tasks

### DIFF
--- a/periodic/tasks.go
+++ b/periodic/tasks.go
@@ -151,7 +151,6 @@ func (t *taskRegistration) getTickerChan() <-chan time.Time {
 // tick starts periodic tasks in response to ticks from t.ticker. The tasks are
 // started in their own goroutine using t.run.
 func (t *taskRegistration) tick() {
-tickloop:
 	for {
 		select {
 		case d := <-t.getTickerChan():
@@ -163,7 +162,7 @@ tickloop:
 				t.control = nil
 				t.ticker.Stop()
 				t.ticker = nil
-				break tickloop
+				return
 			}
 		}
 	}

--- a/periodic/tasks.go
+++ b/periodic/tasks.go
@@ -1,0 +1,149 @@
+//   Copyright 2017 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package periodic
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/trackit/jsonlog"
+)
+
+type contextKey uint
+type taskSignal uint
+
+const (
+	Hourly      = 1 * time.Hour
+	Daily       = 24 * time.Hour
+	TwiceDaily  = Daily / 2
+	ThriceDaily = Daily / 3
+
+	TaskTime = contextKey(iota)
+
+	taskStop = taskSignal(iota)
+)
+
+type Task func(context.Context) error
+
+type taskRegistration struct {
+	Name    string `json:"name"`
+	task    Task
+	Period  time.Duration
+	ticker  *time.Ticker
+	control chan taskSignal
+}
+
+type Scheduler struct {
+	running       bool
+	registrations []taskRegistration
+	mutex         sync.RWMutex
+}
+
+func (s *Scheduler) Running() bool {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.running
+}
+
+func (s *Scheduler) Register(t Task, p time.Duration, n string) {
+	r := taskRegistration{
+		task:   t,
+		Period: p,
+		Name:   n,
+	}
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.running {
+		r.start()
+	}
+	s.registrations = append(s.registrations, r)
+}
+
+func (s *Scheduler) Start() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.running {
+		jsonlog.Error("Attempt to start already started scheduler. Ignoring.", nil)
+	} else {
+		for i := range s.registrations {
+			s.registrations[i].start()
+		}
+		s.running = true
+	}
+}
+
+func (s *Scheduler) Stop() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.running {
+		for i := range s.registrations {
+			s.registrations[i].stop()
+		}
+		s.running = false
+	}
+}
+
+func (t *taskRegistration) start() {
+	if t.control == nil {
+		t.ticker = time.NewTicker(t.Period)
+		t.control = make(chan taskSignal)
+		go t.tick()
+	} else {
+		jsonlog.Error("Attempt to start already started task. Ignoring.", t)
+	}
+}
+
+func (t *taskRegistration) run(d time.Time) error {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, TaskTime, d)
+	return t.task(ctx)
+}
+
+func (t *taskRegistration) getTickerChan() <-chan time.Time {
+	c := t.ticker
+	if c == nil {
+		return nil
+	} else {
+		return c.C
+	}
+}
+
+func (t *taskRegistration) tick() {
+tickloop:
+	for {
+		select {
+		case d := <-t.getTickerChan():
+			go t.run(d)
+		case s := <-t.control:
+			switch s {
+			case taskStop:
+				close(t.control)
+				t.control = nil
+				t.ticker.Stop()
+				t.ticker = nil
+				break tickloop
+			}
+		}
+	}
+}
+
+func (t *taskRegistration) stop() {
+	if t.control != nil {
+		t.control <- taskStop
+	} else {
+		jsonlog.Error("Attempt to stop an already stopped task. Ignoring.", t)
+	}
+}

--- a/periodic/tasks_test.go
+++ b/periodic/tasks_test.go
@@ -20,16 +20,16 @@ func messageTask(c chan<- int, i int) Task {
 	}
 }
 
-func TestRunningSchedulerIsRunning(t *testing.T) {
+func TestTickingSchedulerIsTicking(t *testing.T) {
 	var s Scheduler
 	s.Start()
-	if s.Running() != true {
-		t.Errorf("Running scheduler should be marked running, isn't.")
+	if s.Ticking() != true {
+		t.Errorf("Ticking scheduler should be marked running, isn't.")
 	}
 	s.Stop()
 }
 
-func TestRegisterAtRunningScheduler(t *testing.T) {
+func TestRegisterAtTickingScheduler(t *testing.T) {
 	var s Scheduler
 	var a int
 	c := make(chan int)
@@ -55,14 +55,14 @@ out:
 	s.Stop()
 }
 
-func TestNotRunningSchedulerIsNotRunning(t *testing.T) {
+func TestNotTickingSchedulerIsNotTicking(t *testing.T) {
 	var s Scheduler
-	if s.Running() != false {
+	if s.Ticking() != false {
 		t.Errorf("Never started scheduler should not be marked running. Is.")
 	}
 	s.Start()
 	s.Stop()
-	if s.Running() != false {
+	if s.Ticking() != false {
 		t.Errorf("Started-then-stopped scheduler should not be marked running. Is.")
 	}
 }

--- a/periodic/tasks_test.go
+++ b/periodic/tasks_test.go
@@ -1,0 +1,98 @@
+package periodic
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/trackit/jsonlog"
+)
+
+func init() {
+	jsonlog.DefaultLogger = jsonlog.DefaultLogger.WithLogLevel(jsonlog.LogLevelDebug)
+}
+
+func messageTask(c chan<- int, i int) Task {
+	return func(_ context.Context) error {
+		c <- i
+		return nil
+	}
+}
+
+func TestRunningSchedulerIsRunning(t *testing.T) {
+	var s Scheduler
+	s.Start()
+	if s.Running() != true {
+		t.Errorf("Running scheduler should be marked running, isn't.")
+	}
+	s.Stop()
+}
+
+func TestRegisterAtRunningScheduler(t *testing.T) {
+	var s Scheduler
+	var a int
+	c := make(chan int)
+	s.Start()
+	s.Register(
+		messageTask(c, 0),
+		100*time.Millisecond,
+		"Tenth of a second",
+	)
+	e := time.After(350 * time.Millisecond)
+out:
+	for {
+		select {
+		case <-c:
+			a++
+		case <-e:
+			break out
+		}
+	}
+	if a != 3 {
+		t.Errorf("Task should run %d times, ran %d times.", 3, a)
+	}
+	s.Stop()
+}
+
+func TestNotRunningSchedulerIsNotRunning(t *testing.T) {
+	var s Scheduler
+	if s.Running() != false {
+		t.Errorf("Never started scheduler should not be marked running. Is.")
+	}
+	s.Start()
+	s.Stop()
+	if s.Running() != false {
+		t.Errorf("Started-then-stopped scheduler should not be marked running. Is.")
+	}
+}
+
+func TestTaskCount(t *testing.T) {
+	var s Scheduler
+	var b [10]int
+	var be [10]int = [10]int{4, 4, 3, 3, 3, 3, 2, 2, 2, 2}
+	c := make(chan int)
+	for i := range b {
+		d := time.Duration(217 + i*23)
+		s.Register(
+			messageTask(c, i),
+			d*time.Millisecond,
+			fmt.Sprintf("Task %2d (%3dms)", b, d),
+		)
+	}
+	s.Start()
+	e := time.After(1 * time.Second)
+out:
+	for {
+		select {
+		case i := <-c:
+			b[i]++
+		case <-e:
+			break out
+		}
+	}
+	s.Stop()
+	if b != be {
+		t.Errorf("Expected task count to be %#v, is %#v.", be, b)
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -271,10 +271,10 @@
 			"revisionTime": "2017-03-21T23:07:31Z"
 		},
 		{
-			"checksumSHA1": "GSEtpje73qM1d4p7DsQolilsZrI=",
+			"checksumSHA1": "jU7Zabwi/UEGIoNyWOYt4TFflfA=",
 			"path": "github.com/trackit/jsonlog",
-			"revision": "d693ccc8f433b6b854bc41a69a5903b66f2bd1fa",
-			"revisionTime": "2017-10-10T15:46:04Z"
+			"revision": "01bd840fe38589853b7c3728f982f0cb4bd8e4fa",
+			"revisionTime": "2017-10-31T17:32:46Z"
 		},
 		{
 			"checksumSHA1": "UWjVYmoHlIfHzVIskELHiJQtMOI=",


### PR DESCRIPTION
The `periodic` can register tasks to be run periodically. Currently the tasks are not “aligned” to a date, for example `Hourly` tasks will not be run at the start of each hour, rather at 1-hour intervals after registration.

The tasks are not queued: they are started in their own goroutine regardless of the current load.

While this is a very naive approach it will fulfill our current needs and the API is simple and lenient enough that we can build on top of that later for distributed, queued and smarter scheduling.

TRAC-581