### PR TITLE
server: fix build script shebangs

### DIFF
--- a/server/builddevel.sh
+++ b/server/builddevel.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/server/buildstatic.sh
+++ b/server/buildstatic.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
CircleCI fails because it uses _sh_ to run these scripts due to an incorrect shebang.