### PR TITLE
Updated golang version in Dockerfile

### DIFF
--- a/.circleci/images/primary/Dockerfile
+++ b/.circleci/images/primary/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.1
+FROM golang:1.9.2
 MAINTAINER Victor Schubert <victor@trackit.io>
 
 RUN 	   apt-get update \


### PR DESCRIPTION
Updated golang version to accommodate `>=1.9` only syntax in the code