### PR TITLE
Edit an AWS Account

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -137,6 +137,20 @@ func (a *AwsAccount) CreateAwsAccount(ctx context.Context, db models.XODB) error
 	return err
 }
 
+// UpdateAWSAccount updates an AWS account for a user. It does no error
+// checking: the caller should check themselves that the AWS account exists.
+// Only the Pretty will be updated.
+func (a *AwsAccount) UpdateAWSAccount(ctx context.Context, tx *sql.Tx) error {
+	logger := jsonlog.LoggerFromContextOrDefault(ctx)
+	dbAwsAccount, _ := models.AwsAccountByID(tx, a.Id)
+	dbAwsAccount.Pretty = a.Pretty
+	err := dbAwsAccount.Update(tx)
+	if err != nil {
+		logger.Error("Failed to update AWS account in database.", nil)
+	}
+	return err
+}
+
 // awsAccountFromDbAwsAccount constructs an aws.AwsAccount from a
 // models.AwsAccount. The distinction exists to decouple database access from
 // the logic of the server.

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -137,19 +137,19 @@ func (a *AwsAccount) CreateAwsAccount(ctx context.Context, db models.XODB) error
 	return err
 }
 
-// UpdateAWSAccount updates an AWS account for a user. It does no error
+// UpdatePrettyAWSAccount updates an AWS account for a user. It does no error
 // checking: the caller should check themselves that the AWS account exists.
 // Only the Pretty will be updated.
-func (a *AwsAccount) UpdateAWSAccount(ctx context.Context, tx *sql.Tx) error {
+func (a *AwsAccount) UpdatePrettyAWSAccount(ctx context.Context, tx *sql.Tx) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	dbAwsAccount, err := models.AwsAccountByID(tx, a.Id)
 	if err != nil {
-		logger.Error("Failed to get AWS account in database.", nil)
+		logger.Error("Failed to get AWS account in database.", err.Error())
 	} else {
 		dbAwsAccount.Pretty = a.Pretty
 		err := dbAwsAccount.Update(tx)
 		if err != nil {
-			logger.Error("Failed to update AWS account in database.", nil)
+			logger.Error("Failed to update AWS account in database.", err.Error())
 		}
 	}
 	return err

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -142,11 +142,15 @@ func (a *AwsAccount) CreateAwsAccount(ctx context.Context, db models.XODB) error
 // Only the Pretty will be updated.
 func (a *AwsAccount) UpdateAWSAccount(ctx context.Context, tx *sql.Tx) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
-	dbAwsAccount, _ := models.AwsAccountByID(tx, a.Id)
-	dbAwsAccount.Pretty = a.Pretty
-	err := dbAwsAccount.Update(tx)
+	dbAwsAccount, err := models.AwsAccountByID(tx, a.Id)
 	if err != nil {
-		logger.Error("Failed to update AWS account in database.", nil)
+		logger.Error("Failed to get AWS account in database.", nil)
+	} else {
+		dbAwsAccount.Pretty = a.Pretty
+		err := dbAwsAccount.Update(tx)
+		if err != nil {
+			logger.Error("Failed to update AWS account in database.", nil)
+		}
 	}
 	return err
 }

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -137,10 +137,10 @@ func (a *AwsAccount) CreateAwsAccount(ctx context.Context, db models.XODB) error
 	return err
 }
 
-// UpdatePrettyAWSAccount updates an AWS account for a user. It does no error
+// UpdatePrettyAwsAccount updates an AWS account for a user. It does no error
 // checking: the caller should check themselves that the AWS account exists.
 // Only the Pretty will be updated.
-func (a *AwsAccount) UpdatePrettyAWSAccount(ctx context.Context, tx *sql.Tx) error {
+func (a *AwsAccount) UpdatePrettyAwsAccount(ctx context.Context, tx *sql.Tx) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	dbAwsAccount, err := models.AwsAccountByID(tx, a.Id)
 	if err != nil {

--- a/aws/routeAwsPatch.go
+++ b/aws/routeAwsPatch.go
@@ -44,7 +44,7 @@ func patchAwsAccount(r *http.Request, a routes.Arguments) (int, interface{}) {
 	if err == nil {
 		tx := a[db.Transaction].(*sql.Tx)
 		u := a[users.AuthenticatedUser].(users.User)
-		id := a[QueryArgAwsAccount].(uint)
+		id := a[AwsAccountQueryArg].(int)
 		return patchAwsAccountWithValidBody(r, tx, u, body, int(id))
 	} else {
 		return 400, errors.New("Body is invalid.")
@@ -59,7 +59,7 @@ func patchAwsAccountWithValidBody(r *http.Request, tx *sql.Tx, user users.User, 
 	awsAccount, err := GetAwsAccountWithIdFromUser(user, id, tx)
 	if err == nil {
 		awsAccount.Pretty = body.Pretty
-		if err := awsAccount.UpdateAWSAccount(ctx, tx); err != nil {
+		if err := awsAccount.UpdatePrettyAWSAccount(ctx, tx); err != nil {
 			logger.Error("Failed to update AWS Account.", err)
 			return 500, errFailUpdateAccount
 		}

--- a/aws/routeAwsPatch.go
+++ b/aws/routeAwsPatch.go
@@ -1,0 +1,70 @@
+//   Copyright 2017 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package aws
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+
+	"github.com/trackit/jsonlog"
+
+	"github.com/trackit/trackit2/db"
+	"github.com/trackit/trackit2/routes"
+	"github.com/trackit/trackit2/users"
+)
+
+// patchAwsAccountRequestBody is all the possible bodies for the
+// patchAwsAccount request handler.
+type patchAwsAccountRequestBody struct {
+	Pretty string `json:"pretty"`
+}
+
+var (
+	errFailUpdateAccount = errors.New("Failed to update AWS account.")
+)
+
+// patchAwsAccount is a route handler which lets the user update AwsAccounts from
+// their account.
+func patchAwsAccount(r *http.Request, a routes.Arguments) (int, interface{}) {
+	var body patchAwsAccountRequestBody
+	err := decodeRequestBody(r, &body)
+	if err == nil {
+		tx := a[db.Transaction].(*sql.Tx)
+		u := a[users.AuthenticatedUser].(users.User)
+		id := a[QueryArgAwsAccount].(uint)
+		return patchAwsAccountWithValidBody(r, tx, u, body, int(id))
+	} else {
+		return 400, errors.New("Body is invalid.")
+	}
+}
+
+// patchAwsAccountWithValidBody handles the logic of patchAwsAccount assuming the
+// request body is valid.
+func patchAwsAccountWithValidBody(r *http.Request, tx *sql.Tx, user users.User, body patchAwsAccountRequestBody, id int) (int, interface{}) {
+	ctx := r.Context()
+	logger := jsonlog.LoggerFromContextOrDefault(ctx)
+	awsAccount, err := GetAwsAccountWithIdFromUser(user, id, tx)
+	if err == nil {
+		awsAccount.Pretty = body.Pretty
+		if err := awsAccount.UpdateAWSAccount(ctx, tx); err != nil {
+			return 500, errFailUpdateAccount
+		}
+	} else {
+		logger.Error("Failed to get user's AWS accounts.", err.Error())
+		return 500, errors.New("Failed to retrieve AWS accounts.")
+	}
+	return 200, awsAccount
+}

--- a/aws/routeAwsPatch.go
+++ b/aws/routeAwsPatch.go
@@ -60,6 +60,7 @@ func patchAwsAccountWithValidBody(r *http.Request, tx *sql.Tx, user users.User, 
 	if err == nil {
 		awsAccount.Pretty = body.Pretty
 		if err := awsAccount.UpdateAWSAccount(ctx, tx); err != nil {
+			logger.Error("Failed to update AWS Account.", err)
 			return 500, errFailUpdateAccount
 		}
 	} else {

--- a/aws/routes.go
+++ b/aws/routes.go
@@ -27,6 +27,13 @@ import (
 	"github.com/trackit/trackit2/users"
 )
 
+var (
+	// QueryArgAwsAccount allows to get the AWS Account ID in the URL Parameters
+	// with routes.RequiredQueryArgs. This AWS Account ID will be an Uint stored in
+	// the routes.Arguments map with itself for key.
+	QueryArgAwsAccount = routes.QueryArg{"aa", "AWS Account ID", routes.QueryArgUint{}}
+)
+
 func init() {
 	routes.MethodMuxer{
 		http.MethodGet: routes.H(getAwsAccount).With(
@@ -46,6 +53,14 @@ func init() {
 			routes.Documentation{
 				Summary:     "add an aws account",
 				Description: "Adds an AWS account to the user's list of accounts, validating it before succeeding.",
+			},
+		),
+		http.MethodPatch: routes.H(patchAwsAccount).With(
+			routes.RequestContentType{"application/json"},
+			routes.RequiredQueryArgs{QueryArgAwsAccount},
+			routes.Documentation{
+				Summary:     "edit an aws account",
+				Description: "Edits an AWS account from the user's list of accounts.",
 			},
 		),
 	}.H().With(

--- a/aws/routes.go
+++ b/aws/routes.go
@@ -27,13 +27,6 @@ import (
 	"github.com/trackit/trackit2/users"
 )
 
-var (
-	// QueryArgAwsAccount allows to get the AWS Account ID in the URL Parameters
-	// with routes.RequiredQueryArgs. This AWS Account ID will be an Uint stored in
-	// the routes.Arguments map with itself for key.
-	QueryArgAwsAccount = routes.QueryArg{"aa", "AWS Account ID", routes.QueryArgUint{}}
-)
-
 func init() {
 	routes.MethodMuxer{
 		http.MethodGet: routes.H(getAwsAccount).With(
@@ -57,7 +50,7 @@ func init() {
 		),
 		http.MethodPatch: routes.H(patchAwsAccount).With(
 			routes.RequestContentType{"application/json"},
-			routes.RequiredQueryArgs{QueryArgAwsAccount},
+			routes.RequiredQueryArgs{AwsAccountQueryArg},
 			routes.Documentation{
 				Summary:     "edit an aws account",
 				Description: "Edits an AWS account from the user's list of accounts.",


### PR DESCRIPTION
Added PATCH method to the /aws route to edit an AWS Account. Only the pretty field can be edited.