### PR TITLE
trackit2: add mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Victor Schubert <victor@trackit.io> <v@schu.be>
+Victor Giubilei <victor.g@trackit.io> <giubil@users.noreply.github.com>
+Victor Giubilei <victor.g@trackit.io> <Victor.giubilei@gmail.com>
+Thibaut Cornolti <thibaut@trackit.io> <thibaut@cornolti.eu>
+Thibaut Cornolti <thibaut@trackit.io> <mega-lol@live.fr>


### PR DESCRIPTION
A `.mailmap` file fixes commiter addresses and names in some git views.