### PR TITLE
Fix aws and routes typo

### DIFF
--- a/aws/routeAwsPatch.go
+++ b/aws/routeAwsPatch.go
@@ -59,7 +59,7 @@ func patchAwsAccountWithValidBody(r *http.Request, tx *sql.Tx, user users.User, 
 	awsAccount, err := GetAwsAccountWithIdFromUser(user, id, tx)
 	if err == nil {
 		awsAccount.Pretty = body.Pretty
-		if err := awsAccount.UpdatePrettyAWSAccount(ctx, tx); err != nil {
+		if err := awsAccount.UpdatePrettyAwsAccount(ctx, tx); err != nil {
 			logger.Error("Failed to update AWS Account.", err)
 			return 500, errFailUpdateAccount
 		}

--- a/aws/routes.go
+++ b/aws/routes.go
@@ -50,7 +50,7 @@ func init() {
 		),
 		http.MethodPatch: routes.H(patchAwsAccount).With(
 			routes.RequestContentType{"application/json"},
-			routes.RequiredQueryArgs{AwsAccountQueryArg},
+			routes.QueryArgs{AwsAccountQueryArg},
 			routes.Documentation{
 				Summary:     "edit an aws account",
 				Description: "Edits an AWS account from the user's list of accounts.",

--- a/routes/decoratorQueryArgs.go
+++ b/routes/decoratorQueryArgs.go
@@ -194,7 +194,7 @@ func (qa QueryArgs) getDocumentation(hd HandlerDocumentation) HandlerDocumentati
 	if hd.Tags == nil {
 		hd.Tags = make(Tags)
 	}
-	hd.Tags[TagRequiredContentType] = append(hd.Tags[TagRequiredQueryArg], createDocumentationSlice(TagRequiredQueryArg, false, qa)...)
+	hd.Tags[TagRequiredQueryArg] = append(hd.Tags[TagRequiredQueryArg], createDocumentationSlice(TagRequiredQueryArg, false, qa)...)
 	hd.Tags[TagOptionalQueryArg] = append(hd.Tags[TagOptionalQueryArg], createDocumentationSlice(TagOptionalQueryArg, true, qa)...)
 	return hd
 }


### PR DESCRIPTION
Fixed typo on the `aws` package, and fixed a typo in the `queryArg` documentation generation.