### PR TITLE
Prevent sigsegv in case of elasticsearch error during bill ingestion

### DIFF
--- a/aws/s3/ingestBills.go
+++ b/aws/s3/ingestBills.go
@@ -142,7 +142,6 @@ func afterBulk(ctx context.Context) func(int64, []elastic.BulkableRequest, *elas
 			logger.Error("Failed bulk ElasticSearch requests.", map[string]interface{}{
 				"executionId": execId,
 				"error":       err.Error(),
-				"took":        resp.Took,
 			})
 		} else {
 			logger.Info("Finished bulk ElasticSearch requests.", map[string]interface{}{


### PR DESCRIPTION
In case of elasticsearch error the BulkResponse is nil, therefore trying to access resp.Took creates a SIGSEGV