### PR TITLE
Added copy schema execution to circleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,11 @@ jobs:
             ./buildstatic.sh
       - setup_remote_docker
       - run:
+          name: Copy SQL schema
+          command: |
+            set -xe
+            ./scripts/copy_schema.sh
+      - run:
           name: Build SQL Docker image
           command: |
             set -xe


### PR DESCRIPTION
This fixes the circleCI build, after modification of the way the db schema file is copied.