### PR TITLE
Fixed ES timeout when deleting a billing repository

### DIFF
--- a/es/billingRepository.go
+++ b/es/billingRepository.go
@@ -24,6 +24,6 @@ func CleanByBillRepositoryId(ctx context.Context, aaUId, brId int) error {
 	index := IndexNameForUserId(aaUId, IndexPrefixLineItems)
 	query := elastic.NewBoolQuery()
 	query = query.Filter(elastic.NewTermQuery("billRepositoryId", brId))
-	_, err := elastic.NewDeleteByQueryService(Client).Index(index).Query(query).Do(ctx)
+	_, err := elastic.NewDeleteByQueryService(Client).WaitForCompletion(false).Index(index).Query(query).Do(ctx)
 	return err
 }


### PR DESCRIPTION
This PR fixes the timeout errors we get when trying to delete a billing repository on production.