### PR TITLE
Add EC2 Reports

### DIFF
--- a/aws/ec2/mappings.go
+++ b/aws/ec2/mappings.go
@@ -15,8 +15,8 @@
 package ec2
 
 import (
-	"time"
 	"context"
+	"time"
 
 	"github.com/trackit/jsonlog"
 

--- a/aws/ec2/mappings.go
+++ b/aws/ec2/mappings.go
@@ -23,18 +23,18 @@ import (
 	"github.com/trackit/trackit-server/es"
 )
 
-const TypeLineItem = "ec2-report"
-const IndexPrefixLineItem = "ec2-reports"
-const TemplateNameLineItem = "ec2-reports"
+const TypeEC2Report = "ec2-report"
+const IndexPrefixEC2Report = "ec2-reports"
+const TemplateNameEC2Report = "ec2-reports"
 
 // put the ElasticSearch index for *-ec2-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	res, err := es.Client.IndexPutTemplate(TemplateNameLineItem).BodyString(TemplateLineItem).Do(ctx)
+	res, err := es.Client.IndexPutTemplate(TemplateNameEC2Report).BodyString(TemplateLineItem).Do(ctx)
 	if err != nil {
-		jsonlog.DefaultLogger.Error("Failed to put ES index lineitems.", err)
+		jsonlog.DefaultLogger.Error("Failed to put ES index EC2Report.", err)
 	} else {
-		jsonlog.DefaultLogger.Info("Put ES index lineitems.", res)
+		jsonlog.DefaultLogger.Info("Put ES index EC2Report.", res)
 		ctxCancel()
 	}
 }
@@ -42,7 +42,7 @@ func init() {
 const TemplateLineItem = `
 {
 	"template": "*-ec2-reports",
-	"version": 5,
+	"version": 1,
 	"mappings": {
 		"ec2-report": {
 			"properties": {
@@ -56,7 +56,7 @@ const TemplateLineItem = `
 					"type": "date"
 				},
 				"instances" : {
-					"type": "nested"
+					"type": "nested",
 					"properties": {
 						"id": {
 							"type": "keyword"
@@ -91,4 +91,3 @@ const TemplateLineItem = `
 	}
 }
 `
-

--- a/aws/ec2/mappings.go
+++ b/aws/ec2/mappings.go
@@ -1,0 +1,94 @@
+//   Copyright 2017 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package ec2
+
+import (
+	"time"
+	"context"
+
+	"github.com/trackit/jsonlog"
+
+	"github.com/trackit/trackit-server/es"
+)
+
+const TypeLineItem = "ec2-report"
+const IndexPrefixLineItem = "ec2-reports"
+const TemplateNameLineItem = "ec2-reports"
+
+// put the ElasticSearch index for *-ec2-reports indices at startup.
+func init() {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	res, err := es.Client.IndexPutTemplate(TemplateNameLineItem).BodyString(TemplateLineItem).Do(ctx)
+	if err != nil {
+		jsonlog.DefaultLogger.Error("Failed to put ES index lineitems.", err)
+	} else {
+		jsonlog.DefaultLogger.Info("Put ES index lineitems.", res)
+		ctxCancel()
+	}
+}
+
+const TemplateLineItem = `
+{
+	"template": "*-ec2-reports",
+	"version": 5,
+	"mappings": {
+		"ec2-report": {
+			"properties": {
+				"account": {
+					"type": "keyword"
+				},
+				"reportDate": {
+					"type": "date"
+				},
+				"endDate": {
+					"type": "date"
+				},
+				"instances" : {
+					"type": "nested"
+					"properties": {
+						"id": {
+							"type": "keyword"
+						},
+						"region": {
+							"type": "keyword"
+						},
+						"cpuAverage": {
+							"type": "double"
+						},
+						"cpuPeak": {
+							"type": "double"
+						},
+						"keyPair": {
+							"type": "keyword"
+						},
+						"type": {
+							"type": "keyword"
+						},
+						"tags": {
+							"type": "nested"
+						}
+					}
+				}
+			},
+			"_all": {
+				"enabled": false
+			},
+			"numeric_detection": false,
+			"date_detection": false
+		}
+	}
+}
+`
+

--- a/aws/ec2/monitorInstances.go
+++ b/aws/ec2/monitorInstances.go
@@ -1,0 +1,276 @@
+//   Copyright 2017 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package ec2
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/trackit/jsonlog"
+		taws "github.com/trackit/trackit-server/aws"
+	"github.com/trackit/trackit-server/config"
+	"github.com/trackit/trackit-server/es"
+)
+
+const MonitorInstanceStsSessionName = "monitor-instance"
+
+type (
+	TagName  string
+	TagValue string
+
+	// ReportInfo represents the report with all the informations for EC2 instances.
+	// It will be imported in ElasticSearch thanks to the struct tags.
+	ReportInfo struct {
+		Account    string               `json:"account"`
+		ReportDate time.Time            `json:"reportDate"`
+		Instances  []InstanceInfo		`json:"instances"`
+	}
+
+	// InstanceInfo represents all the informations of an EC2 instance.
+	// It will be imported in ElasticSearch thanks to the struct tags.
+	InstanceInfo struct {
+		Id         string               `json:"id"`
+		Region     string               `json:"region"`
+		CpuAverage float64              `json:"cpuAverage"`
+		CpuPeak    float64              `json:"cpuPeak"`
+		KeyPair    string               `json:"keyPair"`
+		Type       string               `json:"type"`
+		Tags       map[TagName]TagValue `json:"tags"`
+	}
+)
+
+// merge function from https://blog.golang.org/pipelines#TOC_4
+// It allows to merge many chans to one.
+func merge(cs ...<-chan InstanceInfo) <-chan InstanceInfo {
+	var wg sync.WaitGroup
+	out := make(chan InstanceInfo)
+
+	// Start an output goroutine for each input channel in cs. The output
+	// copies values from c to out until c is closed, then calls wg.Done.
+	output := func(c <-chan InstanceInfo) {
+		for n := range c {
+			out <- n
+		}
+		wg.Done()
+	}
+	wg.Add(len(cs))
+	for _, c := range cs {
+		go output(c)
+	}
+
+	// Start a goroutine to close out once all the output goroutines are
+	// done. This must start after the wg.Add call.
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+	return out
+}
+
+// getAccountId gets the AWS Account ID for the given credentials
+func getAccountId(ctx context.Context, sess *session.Session) (string, error) {
+	logger := jsonlog.LoggerFromContextOrDefault(ctx)
+	svc := sts.New(sess)
+	res, err := svc.GetCallerIdentity(nil)
+	if err != nil {
+		logger.Error("Error when getting caller identity", err.Error())
+		return "", err
+	}
+	return aws.StringValue(res.Account), nil
+}
+
+// getInstanceTag formats []*ec2.Tag to map[TagName]TagValue
+func getInstanceTag(tags []*ec2.Tag) map[TagName]TagValue {
+	res := make(map[TagName]TagValue)
+	for _, tag := range tags {
+		res[TagName(aws.StringValue(tag.Key))] = TagValue(aws.StringValue(tag.Value))
+	}
+	return res
+}
+
+func getCurrentCheckedDay() (start time.Time, end time.Time) {
+	now := time.Now()
+	end = time.Date(now.Year(), now.Month(), now.Day()-1, 24, 0, 0, 0, now.Location())
+	start = time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, now.Location())
+	return start, end
+}
+
+// getInstanceStats gets the CPU average and the CPU peak from CloudWatch
+func getInstanceStats(ctx context.Context, instanceId string, sess *session.Session) (float64, float64) {
+	logger := jsonlog.LoggerFromContextOrDefault(ctx)
+	start, end := getCurrentCheckedDay()
+	svc := cloudwatch.New(sess)
+	dimensions := []*cloudwatch.Dimension{
+		&cloudwatch.Dimension{
+			Name:  aws.String("InstanceId"),
+			Value: aws.String(instanceId),
+		},
+	}
+	stats, err := svc.GetMetricStatistics(&cloudwatch.GetMetricStatisticsInput{
+		Namespace:  aws.String("AWS/EC2"),
+		MetricName: aws.String("CPUUtilization"),
+		StartTime:  aws.Time(start),
+		EndTime:    aws.Time(end),
+		Period:     aws.Int64(int64(60 * 60 * 24)), // Period of one hour expressed in seconds
+		Statistics: []*string{aws.String("Average"), aws.String("Maximum")},
+		Dimensions: dimensions,
+	})
+	if err != nil {
+		logger.Error("Error when fetching CPU stats from CloudWatch", err.Error())
+		return 0, 0
+	} else if len(stats.Datapoints) > 0 {
+		return aws.Float64Value(stats.Datapoints[0].Average), aws.Float64Value(stats.Datapoints[0].Maximum)
+	} else {
+		return 0, 0
+	}
+}
+
+// fetchInstancesList sent in instanceInfoChan the instances fetched from DescribeInstances
+// and filled by DescribeInstances, getAccountID and getInstanceStats.
+func fetchInstancesList(ctx context.Context, creds *credentials.Credentials,
+	region string, instanceInfoChan chan InstanceInfo) error {
+	defer close(instanceInfoChan)
+	logger := jsonlog.LoggerFromContextOrDefault(ctx)
+	sess := session.Must(session.NewSession(&aws.Config{
+		Credentials: creds,
+		Region:      aws.String(region),
+	}))
+	svc := ec2.New(sess)
+	instances, err := svc.DescribeInstances(nil)
+	if err != nil {
+		logger.Error("Error when describing instances", err.Error())
+		return err
+	}
+	for _, reservation := range instances.Reservations {
+		for _, instance := range reservation.Instances {
+			CpuAverage, CpuPeak := getInstanceStats(ctx, aws.StringValue(instance.InstanceId), sess)
+			instanceInfoChan <- InstanceInfo{
+				Id:         aws.StringValue(instance.InstanceId),
+				Region:     aws.StringValue(instance.Placement.AvailabilityZone),
+				KeyPair:    aws.StringValue(instance.KeyName),
+				Tags:       getInstanceTag(instance.Tags),
+				Type:       aws.StringValue(instance.InstanceType),
+				CpuAverage: CpuAverage,
+				CpuPeak:    CpuPeak,
+			}
+		}
+	}
+	return nil
+}
+
+// fetchRegionsList fetchs the regions list from AWS and returns an array of their name.
+func fetchRegionsList(ctx context.Context, sess *session.Session) ([]string, error) {
+	logger := jsonlog.LoggerFromContextOrDefault(ctx)
+	svc := ec2.New(sess)
+	regions, err := svc.DescribeRegions(nil)
+	if err != nil {
+		logger.Error("Error when describing regions", err.Error())
+		return []string{}, err
+	}
+	res := make([]string, 0)
+	for _, region := range regions.Regions {
+		res = append(res, aws.StringValue(region.RegionName))
+	}
+	return res, nil
+}
+
+// importInstancesToEs imports an array of InstanceInfo in ElasticSearch.
+// It calls createIndexEs if the index doesn't exist.
+func importInstancesToEs(ctx context.Context, aa taws.AwsAccount, report ReportInfo) error {
+	logger := jsonlog.LoggerFromContextOrDefault(ctx)
+	logger.Info("Updating EC2 instances for AWS account.", map[string]interface{}{
+		"awsAccount":     aa,
+	})
+	client := es.Client
+	ji, err := json.Marshal(struct {
+		Account    string               `json:"account"`
+		ReportDate time.Time            `json:"reportDate"`
+	}{
+		report.Account,
+		report.ReportDate,
+	})
+	if err != nil {
+		logger.Error("Error when marshaling instance var", err.Error())
+		return err
+	}
+	hash := md5.Sum(ji)
+	hash64 := base64.URLEncoding.EncodeToString(hash[:])
+	index := es.IndexNameForUserId(aa.UserId, IndexPrefixLineItem)
+	if res, err := client.
+		Index().
+		Index(index).
+		Type(TypeLineItem).
+		BodyJson(report).
+		Id(hash64).
+		Do(context.Background()); err != nil {
+		logger.Error("Error when putting InstanceInfo in ES", err.Error())
+	} else {
+		logger.Info("Instance put in ES", *res)
+	}
+	return nil
+}
+
+// FetchInstancesStats fetchs the stats of the EC2 instances of an AwsAccount
+// to import them in ElasticSearch. The stats are fetched from the last hour.
+// In this way, FetchInstancesStats should be called every hour.
+func FetchInstancesStats(ctx context.Context, awsAccount taws.AwsAccount) error {
+	logger := jsonlog.LoggerFromContextOrDefault(ctx)
+	logger.Info("Fetching instance stats for "+string(awsAccount.Id)+" ("+awsAccount.Pretty+")", nil)
+	creds, err := taws.GetTemporaryCredentials(awsAccount, MonitorInstanceStsSessionName)
+	if err != nil {
+		logger.Error("Error when getting temporary credentials", err.Error())
+		return err
+	}
+	defaultSession := session.Must(session.NewSession(&aws.Config{
+		Credentials: creds,
+		Region:      aws.String(config.AwsRegion),
+	}))
+	account, err := getAccountId(ctx, defaultSession)
+	if err != nil {
+		logger.Error("Error when getting account id", err.Error())
+		return err
+	}
+	start, _ := getCurrentCheckedDay()
+	report := ReportInfo{
+		account,
+		start,
+		make([]InstanceInfo, 0),
+	}
+	regions, err := fetchRegionsList(ctx, defaultSession)
+	if err != nil {
+		logger.Error("Error when fetching regions list", err.Error())
+		return err
+	}
+	instanceInfoChans := make([]<-chan InstanceInfo, 0, 15)
+	for _, region := range regions {
+		instanceInfoChan := make(chan InstanceInfo)
+		go fetchInstancesList(ctx, creds, region, instanceInfoChan)
+		instanceInfoChans = append(instanceInfoChans, instanceInfoChan)
+	}
+	for instance := range merge(instanceInfoChans...) {
+		report.Instances = append(report.Instances, instance)
+	}
+	return importInstancesToEs(ctx, awsAccount, report)
+}

--- a/aws/ec2/monitorInstances.go
+++ b/aws/ec2/monitorInstances.go
@@ -113,7 +113,7 @@ func getInstanceTag(tags []*ec2.Tag) map[TagName]TagValue {
 func getCurrentCheckedDay() (start time.Time, end time.Time) {
 	now := time.Now()
 	end = time.Date(now.Year(), now.Month(), now.Day()-1, 24, 0, 0, 0, now.Location())
-	start = time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, now.Location())
+	start = time.Date(now.Year(), now.Month(), now.Day()-31, 0, 0, 0, 0, now.Location())
 	return start, end
 }
 
@@ -133,7 +133,7 @@ func getInstanceStats(ctx context.Context, instanceId string, sess *session.Sess
 		MetricName: aws.String("CPUUtilization"),
 		StartTime:  aws.Time(start),
 		EndTime:    aws.Time(end),
-		Period:     aws.Int64(int64(60 * 60 * 24)), // Period of one hour expressed in seconds
+		Period:     aws.Int64(int64(60 * 60 * 24) * 30), // Period of one hour expressed in seconds
 		Statistics: []*string{aws.String("Average"), aws.String("Maximum")},
 		Dimensions: dimensions,
 	})
@@ -252,10 +252,10 @@ func FetchInstancesStats(ctx context.Context, awsAccount taws.AwsAccount) error 
 		logger.Error("Error when getting account id", err.Error())
 		return err
 	}
-	start, _ := getCurrentCheckedDay()
+	now := time.Now()
 	report := ReportInfo{
 		account,
-		start,
+		time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, now.Location()),
 		make([]InstanceInfo, 0),
 	}
 	regions, err := fetchRegionsList(ctx, defaultSession)

--- a/aws/ec2/monitorInstances.go
+++ b/aws/ec2/monitorInstances.go
@@ -29,7 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/trackit/jsonlog"
-		taws "github.com/trackit/trackit-server/aws"
+	taws "github.com/trackit/trackit-server/aws"
 	"github.com/trackit/trackit-server/config"
 	"github.com/trackit/trackit-server/es"
 )
@@ -43,21 +43,21 @@ type (
 	// ReportInfo represents the report with all the informations for EC2 instances.
 	// It will be imported in ElasticSearch thanks to the struct tags.
 	ReportInfo struct {
-		Account    string               `json:"account"`
-		ReportDate time.Time            `json:"reportDate"`
-		Instances  []InstanceInfo		`json:"instances"`
+		Account		string				`json:"account"`
+		ReportDate	time.Time			`json:"reportDate"`
+		Instances	[]InstanceInfo		`json:"instances"`
 	}
 
 	// InstanceInfo represents all the informations of an EC2 instance.
 	// It will be imported in ElasticSearch thanks to the struct tags.
 	InstanceInfo struct {
-		Id         string               `json:"id"`
-		Region     string               `json:"region"`
-		CpuAverage float64              `json:"cpuAverage"`
-		CpuPeak    float64              `json:"cpuPeak"`
-		KeyPair    string               `json:"keyPair"`
-		Type       string               `json:"type"`
-		Tags       map[TagName]TagValue `json:"tags"`
+		Id			string					`json:"id"`
+		Region		string					`json:"region"`
+		CpuAverage	float64					`json:"cpuAverage"`
+		CpuPeak		float64					`json:"cpuPeak"`
+		KeyPair		string					`json:"keyPair"`
+		Type		string					`json:"type"`
+		Tags		map[TagName]TagValue	`json:"tags"`
 	}
 )
 
@@ -217,11 +217,11 @@ func importInstancesToEs(ctx context.Context, aa taws.AwsAccount, report ReportI
 	}
 	hash := md5.Sum(ji)
 	hash64 := base64.URLEncoding.EncodeToString(hash[:])
-	index := es.IndexNameForUserId(aa.UserId, IndexPrefixLineItem)
+	index := es.IndexNameForUserId(aa.UserId, IndexPrefixEC2Report)
 	if res, err := client.
 		Index().
 		Index(index).
-		Type(TypeLineItem).
+		Type(TypeEC2Report).
 		BodyJson(report).
 		Id(hash64).
 		Do(context.Background()); err != nil {

--- a/aws/ec2/monitorInstances.go
+++ b/aws/ec2/monitorInstances.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/trackit/jsonlog"
+
 	taws "github.com/trackit/trackit-server/aws"
 	"github.com/trackit/trackit-server/config"
 	"github.com/trackit/trackit-server/es"
@@ -43,21 +44,21 @@ type (
 	// ReportInfo represents the report with all the informations for EC2 instances.
 	// It will be imported in ElasticSearch thanks to the struct tags.
 	ReportInfo struct {
-		Account		string				`json:"account"`
-		ReportDate	time.Time			`json:"reportDate"`
-		Instances	[]InstanceInfo		`json:"instances"`
+		Account    string         `json:"account"`
+		ReportDate time.Time      `json:"reportDate"`
+		Instances  []InstanceInfo `json:"instances"`
 	}
 
 	// InstanceInfo represents all the informations of an EC2 instance.
 	// It will be imported in ElasticSearch thanks to the struct tags.
 	InstanceInfo struct {
-		Id			string					`json:"id"`
-		Region		string					`json:"region"`
-		CpuAverage	float64					`json:"cpuAverage"`
-		CpuPeak		float64					`json:"cpuPeak"`
-		KeyPair		string					`json:"keyPair"`
-		Type		string					`json:"type"`
-		Tags		map[TagName]TagValue	`json:"tags"`
+		Id         string               `json:"id"`
+		Region     string               `json:"region"`
+		CpuAverage float64              `json:"cpuAverage"`
+		CpuPeak    float64              `json:"cpuPeak"`
+		KeyPair    string               `json:"keyPair"`
+		Type       string               `json:"type"`
+		Tags       map[TagName]TagValue `json:"tags"`
 	}
 )
 
@@ -133,7 +134,7 @@ func getInstanceStats(ctx context.Context, instanceId string, sess *session.Sess
 		MetricName: aws.String("CPUUtilization"),
 		StartTime:  aws.Time(start),
 		EndTime:    aws.Time(end),
-		Period:     aws.Int64(int64(60 * 60 * 24) * 30), // Period of one hour expressed in seconds
+		Period:     aws.Int64(int64(60*60*24) * 30), // Period of one hour expressed in seconds
 		Statistics: []*string{aws.String("Average"), aws.String("Maximum")},
 		Dimensions: dimensions,
 	})
@@ -201,12 +202,12 @@ func fetchRegionsList(ctx context.Context, sess *session.Session) ([]string, err
 func importInstancesToEs(ctx context.Context, aa taws.AwsAccount, report ReportInfo) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Updating EC2 instances for AWS account.", map[string]interface{}{
-		"awsAccount":     aa,
+		"awsAccount": aa,
 	})
 	client := es.Client
 	ji, err := json.Marshal(struct {
-		Account    string               `json:"account"`
-		ReportDate time.Time            `json:"reportDate"`
+		Account    string    `json:"account"`
+		ReportDate time.Time `json:"reportDate"`
 	}{
 		report.Account,
 		report.ReportDate,
@@ -252,10 +253,9 @@ func FetchInstancesStats(ctx context.Context, awsAccount taws.AwsAccount) error 
 		logger.Error("Error when getting account id", err.Error())
 		return err
 	}
-	now := time.Now()
 	report := ReportInfo{
 		account,
-		time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, now.Location()),
+		time.Now(),
 		make([]InstanceInfo, 0),
 	}
 	regions, err := fetchRegionsList(ctx, defaultSession)

--- a/db/migration/0007_ec2_support_for_aws_account_update_job.sql
+++ b/db/migration/0007_ec2_support_for_aws_account_update_job.sql
@@ -1,0 +1,15 @@
+--   Copyright 2018 MSolution.IO
+--
+--   Licensed under the Apache License, Version 2.0 (the "License");
+--   you may not use this file except in compliance with the License.
+--   You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--   Unless required by applicable law or agreed to in writing, software
+--   distributed under the License is distributed on an "AS IS" BASIS,
+--   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--   See the License for the specific language governing permissions and
+--   limitations under the License.
+
+ALTER TABLE aws_account_update_job ADD ec2Error VARCHAR(255) NOT NULL DEFAULT "";

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -205,3 +205,19 @@ ALTER TABLE aws_account ADD grace_update DATETIME NOT NULL DEFAULT "1970-01-01 0
 CREATE VIEW aws_account_due_update AS
 	SELECT * FROM aws_account WHERE next_update <= NOW() AND grace_update <= NOW()
 ;
+
+--   Copyright 2018 MSolution.IO
+--
+--   Licensed under the Apache License, Version 2.0 (the "License");
+--   you may not use this file except in compliance with the License.
+--   You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--   Unless required by applicable law or agreed to in writing, software
+--   distributed under the License is distributed on an "AS IS" BASIS,
+--   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--   See the License for the specific language governing permissions and
+--   limitations under the License.
+
+ALTER TABLE aws_account_update_job ADD ec2Error VARCHAR(255) NOT NULL DEFAULT "";

--- a/ec2/ec2_route.go
+++ b/ec2/ec2_route.go
@@ -18,9 +18,7 @@ import (
 	"net/http"
 	"context"
 	"fmt"
-	"time"
-
-	"github.com/trackit/jsonlog"
+		"github.com/trackit/jsonlog"
 	"github.com/trackit/trackit-server/aws"
 	"github.com/trackit/trackit-server/aws/ec2"
 	"github.com/trackit/trackit-server/db"
@@ -33,8 +31,6 @@ import (
 
 // esQueryParams will store the parsed query params
 type esQueryParams struct {
-	dateBegin         time.Time
-	dateEnd           time.Time
 	accountList       []string
 }
 
@@ -47,8 +43,6 @@ var ec2QueryArgs = []routes.QueryArg{
 		Type:        routes.QueryArgStringSlice{},
 		Optional:    true,
 	},
-	routes.DateBeginQueryArg,
-	routes.DateEndQueryArg,
 }
 
 func init() {
@@ -76,8 +70,6 @@ func makeElasticSearchRequest(ctx context.Context, parsedParams esQueryParams, u
 	index := es.IndexNameForUser(user, ec2.IndexPrefixLineItem)
 	searchService := GetElasticSearchParams(
 		parsedParams.accountList,
-		parsedParams.dateBegin,
-		parsedParams.dateEnd,
 		es.Client,
 		index,
 	)
@@ -98,8 +90,6 @@ func getEc2Instances(request *http.Request, a routes.Arguments) (int, interface{
 	user := a[users.AuthenticatedUser].(users.User)
 	parsedParams := esQueryParams{
 		accountList:       []string{},
-		dateBegin:         a[ec2QueryArgs[1]].(time.Time),
-		dateEnd:           a[ec2QueryArgs[2]].(time.Time),
 	}
 	if a[ec2QueryArgs[0]] != nil {
 		parsedParams.accountList = a[ec2QueryArgs[0]].([]string)

--- a/ec2/ec2_route.go
+++ b/ec2/ec2_route.go
@@ -1,0 +1,119 @@
+//   Copyright 2017 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package ec2
+
+import (
+	"net/http"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/trackit/jsonlog"
+	"github.com/trackit/trackit-server/aws"
+	"github.com/trackit/trackit-server/aws/ec2"
+	"github.com/trackit/trackit-server/db"
+	"github.com/trackit/trackit-server/routes"
+	"github.com/trackit/trackit-server/users"
+	"github.com/trackit/trackit-server/es"
+
+	"gopkg.in/olivere/elastic.v5"
+	)
+
+// esQueryParams will store the parsed query params
+type esQueryParams struct {
+	dateBegin         time.Time
+	dateEnd           time.Time
+	accountList       []string
+}
+
+// ec2QueryArgs allows to get required queryArgs params
+var ec2QueryArgs = []routes.QueryArg{
+	// TODO (BREAKING CHANGE): replace by routes.AwsAccountsOptionalQueryArg
+	routes.QueryArg{
+		Name:        "accounts",
+		Description: "List of comma separated AWS accounts ids",
+		Type:        routes.QueryArgStringSlice{},
+		Optional:    true,
+	},
+	routes.DateBeginQueryArg,
+	routes.DateEndQueryArg,
+}
+
+func init() {
+	routes.MethodMuxer{
+		http.MethodGet: routes.H(getEc2Instances).With(
+			db.RequestTransaction{Db: db.Db},
+			users.RequireAuthenticatedUser{users.ViewerAsParent},
+			routes.QueryArgs(ec2QueryArgs),
+			routes.Documentation{
+				Summary:     "get the list of EC2 instances",
+				Description: "Responds with the list of EC2 instances based on the queryparams passed to it",
+			},
+		),
+	}.H().Register("/ec2")
+}
+
+// makeElasticSearchRequestAndParseIt will make the actual request to the ElasticSearch parse the results and return them
+// It will return the data, an http status code (as int) and an error.
+// Because an error can be generated, but is not critical and is not needed to be known by
+// the user (e.g if the index does not exists because it was not yet indexed ) the error will
+// be returned, but instead of having a 500 status code, it will return the provided status code
+// with empy data
+func makeElasticSearchRequest(ctx context.Context, parsedParams esQueryParams, user users.User) (*elastic.SearchResult, int, error) {
+	l := jsonlog.LoggerFromContextOrDefault(ctx)
+	index := es.IndexNameForUser(user, ec2.IndexPrefixLineItem)
+	searchService := GetElasticSearchParams(
+		parsedParams.accountList,
+		parsedParams.dateBegin,
+		parsedParams.dateEnd,
+		es.Client,
+		index,
+	)
+	res, err := searchService.Do(ctx)
+	if err != nil {
+		if elastic.IsNotFound(err) {
+			l.Warning("Query execution failed, ES index does not exists : "+index, err)
+			return nil, http.StatusOK, err
+		}
+		l.Error("Query execution failed : "+err.Error(), nil)
+		return nil, http.StatusInternalServerError, fmt.Errorf("could not execute the ElasticSearch query")
+	}
+	return res, http.StatusOK, nil
+}
+
+// getEc2Instances returns the list of EC2 instances based on the query params, in JSON format.
+func getEc2Instances(request *http.Request, a routes.Arguments) (int, interface{}) {
+	user := a[users.AuthenticatedUser].(users.User)
+	parsedParams := esQueryParams{
+		accountList:       []string{},
+		dateBegin:         a[ec2QueryArgs[1]].(time.Time),
+		dateEnd:           a[ec2QueryArgs[2]].(time.Time),
+	}
+	if a[ec2QueryArgs[0]] != nil {
+		parsedParams.accountList = a[ec2QueryArgs[0]].([]string)
+	}
+	if err := aws.ValidateAwsAccounts(parsedParams.accountList); err != nil {
+		return http.StatusBadRequest, err
+	}
+	report, returnCode, err := makeElasticSearchRequest(request.Context(), parsedParams, user)
+	if err != nil {
+		return returnCode, err
+	}
+	res, err := prepareResponse(request.Context(), report)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+	return http.StatusOK, res
+}

--- a/ec2/ec2_route.go
+++ b/ec2/ec2_route.go
@@ -18,16 +18,18 @@ import (
 	"net/http"
 	"context"
 	"fmt"
-		"github.com/trackit/jsonlog"
+
+	"gopkg.in/olivere/elastic.v5"
+
+	"github.com/trackit/jsonlog"
+
 	"github.com/trackit/trackit-server/aws"
 	"github.com/trackit/trackit-server/aws/ec2"
 	"github.com/trackit/trackit-server/db"
 	"github.com/trackit/trackit-server/routes"
 	"github.com/trackit/trackit-server/users"
 	"github.com/trackit/trackit-server/es"
-
-	"gopkg.in/olivere/elastic.v5"
-	)
+)
 
 // esQueryParams will store the parsed query params
 type esQueryParams struct {

--- a/ec2/ec2_route.go
+++ b/ec2/ec2_route.go
@@ -15,25 +15,24 @@
 package ec2
 
 import (
-	"net/http"
 	"context"
 	"fmt"
-
-	"gopkg.in/olivere/elastic.v5"
+	"net/http"
 
 	"github.com/trackit/jsonlog"
+	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit-server/aws"
 	"github.com/trackit/trackit-server/aws/ec2"
 	"github.com/trackit/trackit-server/db"
+	"github.com/trackit/trackit-server/es"
 	"github.com/trackit/trackit-server/routes"
 	"github.com/trackit/trackit-server/users"
-	"github.com/trackit/trackit-server/es"
 )
 
 // esQueryParams will store the parsed query params
 type esQueryParams struct {
-	account		string
+	account string
 }
 
 // ec2QueryArgs allows to get required queryArgs params
@@ -85,7 +84,7 @@ func makeElasticSearchRequest(ctx context.Context, parsedParams esQueryParams, u
 func getEc2Instances(request *http.Request, a routes.Arguments) (int, interface{}) {
 	user := a[users.AuthenticatedUser].(users.User)
 	parsedParams := esQueryParams{
-		account:	"",
+		account: "",
 	}
 	if a[ec2QueryArgs[0]] != nil {
 		parsedParams.account = a[ec2QueryArgs[0]].(string)

--- a/ec2/es_request_constructor.go
+++ b/ec2/es_request_constructor.go
@@ -17,8 +17,7 @@ package ec2
 
 import (
 	"gopkg.in/olivere/elastic.v5"
-	"time"
-)
+	)
 
 // queryMaxSize is the maximum size of an Elastic Search Query
 const queryMaxSize = 10000
@@ -30,13 +29,6 @@ func createQueryAccountFilter(accountList []string) *elastic.TermsQuery {
 		accountListFormatted[i] = v
 	}
 	return elastic.NewTermsQuery("account", accountListFormatted...)
-}
-
-// createQueryTimeRange creates and return a new *elastic.RangeQuery based on the duration
-// defined by durationBegin and durationEnd
-func createQueryTimeRange(durationBegin time.Time, durationEnd time.Time) *elastic.RangeQuery {
-	return elastic.NewRangeQuery("reportDate").
-		From(durationBegin).To(durationEnd)
 }
 
 // GetElasticSearchParams is used to construct an ElasticSearch *elastic.SearchService used to perform a request on ES
@@ -51,13 +43,11 @@ func createQueryTimeRange(durationBegin time.Time, durationEnd time.Time) *elast
 // it crash :
 //	- If the client is nil or malconfigured, it will crash
 //	- If the index is not an index present in the ES, it will crash
-func GetElasticSearchParams(accountList []string, durationBegin time.Time,
-	durationEnd time.Time, client *elastic.Client, index string) *elastic.SearchService {
+func GetElasticSearchParams(accountList []string, client *elastic.Client, index string) *elastic.SearchService {
 	query := elastic.NewBoolQuery()
 	if len(accountList) > 0 {
 		query = query.Filter(createQueryAccountFilter(accountList))
 	}
-	query = query.Filter(createQueryTimeRange(durationBegin, durationEnd))
-	search := client.Search().Index(index).Size(queryMaxSize).Query(query)
+	search := client.Search().Index(index).Query(query).Sort("reportDate", false).Size(1)
 	return search
 }

--- a/ec2/es_request_constructor.go
+++ b/ec2/es_request_constructor.go
@@ -1,0 +1,63 @@
+//   Copyright 2017 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+// Package costs gets billing information from an ElasticSearch.
+package ec2
+
+import (
+	"gopkg.in/olivere/elastic.v5"
+	"time"
+)
+
+// queryMaxSize is the maximum size of an Elastic Search Query
+const queryMaxSize = 10000
+
+// createQueryAccountFilter creates and return a new *elastic.TermsQuery on the accountList array
+func createQueryAccountFilter(accountList []string) *elastic.TermsQuery {
+	accountListFormatted := make([]interface{}, len(accountList))
+	for i, v := range accountList {
+		accountListFormatted[i] = v
+	}
+	return elastic.NewTermsQuery("account", accountListFormatted...)
+}
+
+// createQueryTimeRange creates and return a new *elastic.RangeQuery based on the duration
+// defined by durationBegin and durationEnd
+func createQueryTimeRange(durationBegin time.Time, durationEnd time.Time) *elastic.RangeQuery {
+	return elastic.NewRangeQuery("reportDate").
+		From(durationBegin).To(durationEnd)
+}
+
+// GetElasticSearchParams is used to construct an ElasticSearch *elastic.SearchService used to perform a request on ES
+// It takes as paramters :
+// 	- accountList []string : A slice of strings representing aws account number, in the format of the field
+//	'awsdetailedlineitem.linked_account_id'
+//	- client *elastic.Client : an instance of *elastic.Client that represent an Elastic Search client.
+//	It needs to be fully configured and ready to execute a client.Search()
+//	- index string : The Elastic Search index on wich to execute the query. In this context the default value
+//	should be "awsdetailedlineitems"
+// This function excepts arguments passed to it to be sanitize. If they are not, the following cases will make
+// it crash :
+//	- If the client is nil or malconfigured, it will crash
+//	- If the index is not an index present in the ES, it will crash
+func GetElasticSearchParams(accountList []string, durationBegin time.Time,
+	durationEnd time.Time, client *elastic.Client, index string) *elastic.SearchService {
+	query := elastic.NewBoolQuery()
+	if len(accountList) > 0 {
+		query = query.Filter(createQueryAccountFilter(accountList))
+	}
+	query = query.Filter(createQueryTimeRange(durationBegin, durationEnd))
+	search := client.Search().Index(index).Size(queryMaxSize).Query(query)
+	return search
+}

--- a/ec2/es_request_constructor.go
+++ b/ec2/es_request_constructor.go
@@ -20,12 +20,10 @@ import (
 )
 
 // createQueryAccountFilter creates and return a new *elastic.TermsQuery on the accountList array
-func createQueryAccountFilter(accountList []string) *elastic.TermsQuery {
-	accountListFormatted := make([]interface{}, len(accountList))
-	for i, v := range accountList {
-		accountListFormatted[i] = v
-	}
-	return elastic.NewTermsQuery("account", accountListFormatted...)
+func createQueryAccountFilter(account string) *elastic.TermsQuery {
+	accountFormatted := make([]interface{}, 1)
+	accountFormatted[0] = account
+	return elastic.NewTermsQuery("account", accountFormatted...)
 }
 
 // GetElasticSearchParams is used to construct an ElasticSearch *elastic.SearchService used to perform a request on ES
@@ -40,11 +38,9 @@ func createQueryAccountFilter(accountList []string) *elastic.TermsQuery {
 // it crash :
 //	- If the client is nil or malconfigured, it will crash
 //	- If the index is not an index present in the ES, it will crash
-func GetElasticSearchParams(accountList []string, client *elastic.Client, index string) *elastic.SearchService {
+func GetElasticSearchParams(account string, client *elastic.Client, index string) *elastic.SearchService {
 	query := elastic.NewBoolQuery()
-	if len(accountList) > 0 {
-		query = query.Filter(createQueryAccountFilter(accountList))
-	}
+	query = query.Filter(createQueryAccountFilter(account))
 	search := client.Search().Index(index).Query(query).Sort("reportDate", false).Size(1)
 	return search
 }

--- a/ec2/es_request_constructor.go
+++ b/ec2/es_request_constructor.go
@@ -17,10 +17,7 @@ package ec2
 
 import (
 	"gopkg.in/olivere/elastic.v5"
-	)
-
-// queryMaxSize is the maximum size of an Elastic Search Query
-const queryMaxSize = 10000
+)
 
 // createQueryAccountFilter creates and return a new *elastic.TermsQuery on the accountList array
 func createQueryAccountFilter(accountList []string) *elastic.TermsQuery {

--- a/ec2/prepare_response.go
+++ b/ec2/prepare_response.go
@@ -25,7 +25,7 @@ import (
 )
 
 // parseESResult parses an *elastic.SearchResult according to it's resultType
-func parseESResult(ctx context.Context, res *elastic.SearchResult) ([]ec2.ReportInfo, error) {
+func parseESResult(ctx context.Context, res *elastic.SearchResult) (*ec2.ReportInfo, error) {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	reports := make([]ec2.ReportInfo, 0)
 	for _, hit := range res.Hits.Hits {
@@ -37,14 +37,14 @@ func parseESResult(ctx context.Context, res *elastic.SearchResult) ([]ec2.Report
 		}
 		reports = append(reports, parsedDocument)
 	}
-	return reports, nil
+	return &reports[0], nil
 }
 
 // prepareResponse parses the results from elasticsearch and returns a list of EC2 reports with stats of each instances
 func prepareResponse(ctx context.Context, rawReport *elastic.SearchResult) (interface{}, error) {
-	reports, err := parseESResult(ctx, rawReport)
+	report, err := parseESResult(ctx, rawReport)
 	if err != nil {
 		return nil, err
 	}
-	return reports, nil
+	return report, nil
 }

--- a/ec2/prepare_response.go
+++ b/ec2/prepare_response.go
@@ -1,0 +1,50 @@
+//   Copyright 2017 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package ec2
+
+import (
+	"context"
+	"encoding/json"
+
+	"gopkg.in/olivere/elastic.v5"
+
+	"github.com/trackit/jsonlog"
+	"github.com/trackit/trackit-server/aws/ec2"
+)
+
+// parseESResult parses an *elastic.SearchResult according to it's resultType
+func parseESResult(ctx context.Context, res *elastic.SearchResult) ([]ec2.ReportInfo, error) {
+	logger := jsonlog.LoggerFromContextOrDefault(ctx)
+	reports := make([]ec2.ReportInfo, 0)
+	for _, hit := range res.Hits.Hits {
+		var parsedDocument ec2.ReportInfo
+		err := json.Unmarshal(*hit.Source, &parsedDocument)
+		if err != nil {
+			logger.Error("Failed to parse elasticsearch document.", err.Error())
+			return nil, err
+		}
+		reports = append(reports, parsedDocument)
+	}
+	return reports, nil
+}
+
+// prepareResponse parses the results from elasticsearch and returns a list of EC2 reports with stats of each instances
+func prepareResponse(ctx context.Context, rawReport *elastic.SearchResult) (interface{}, error) {
+	reports, err := parseESResult(ctx, rawReport)
+	if err != nil {
+		return nil, err
+	}
+	return reports, nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/trackit/trackit-server/periodic"
 	_ "github.com/trackit/trackit-server/reports"
 	"github.com/trackit/trackit-server/routes"
+	_ "github.com/trackit/trackit-server/ec2"
 	_ "github.com/trackit/trackit-server/s3/costs"
 	_ "github.com/trackit/trackit-server/users"
 )

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -19,34 +19,34 @@
 			"revisionTime": "2017-02-16T02:04:25Z"
 		},
 		{
-			"checksumSHA1": "eRUmyUWvOPK7gRZCc3g3TqwBnr8=",
+			"checksumSHA1": "wQmtBK3iXJi1O/hKdD5wfCIeMb4=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
-			"checksumSHA1": "9nE/FjZ4pYrT883KtV2/aI+Gayo=",
+			"checksumSHA1": "EwL79Cq6euk+EV/t/n2E+jzPNmU=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
-			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
+			"checksumSHA1": "uEJU4I6dTKaraQKvrljlYKUZwoc=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
 			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
@@ -55,10 +55,10 @@
 			"revisionTime": "2017-10-13T17:55:20Z"
 		},
 		{
-			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
+			"checksumSHA1": "925zPp8gtaXi2gkWrgZ1gAA003A=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
@@ -91,16 +91,16 @@
 			"revisionTime": "2017-10-13T17:55:20Z"
 		},
 		{
-			"checksumSHA1": "3Zvhi9PXEQXGz8e7FE2RcxBXZ0s=",
+			"checksumSHA1": "Q1co3y5Y8rRIEjEXEfUZ9SwTmic=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
-			"checksumSHA1": "9GvAyILJ7g+VUg8Ef5DsT5GuYsg=",
+			"checksumSHA1": "Ia/AZ2fZp7J4lMO6fpkvfLU/HGY=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
 			"checksumSHA1": "HcGL4e6Uep4/80eCUI5xkcWjpQ0=",
@@ -109,40 +109,58 @@
 			"revisionTime": "2017-10-13T17:55:20Z"
 		},
 		{
-			"checksumSHA1": "iU00ZjhAml/13g+1YXT21IqoXqg=",
+			"checksumSHA1": "Dj9WOMBPbboyUJV4GB99PwPcO4g=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
+		},
+		{
+			"checksumSHA1": "wjxQlU1PYxrDRFoL1Vek8Wch7jk=",
+			"path": "github.com/aws/aws-sdk-go/internal/sdkio",
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
+		},
+		{
+			"checksumSHA1": "MYLldFRnsZh21TfCkgkXCT3maPU=",
+			"path": "github.com/aws/aws-sdk-go/internal/sdkrand",
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
-			"checksumSHA1": "NStHCXEvYqG72GknZyv1jaKaeH0=",
+			"checksumSHA1": "ZX5QHZb0PrK4UF45um2kaAEiX+8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
-			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
+			"checksumSHA1": "GQuRJY72iGQrufDqIaB50zG27u0=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
+			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
+			"revisionTime": "2018-07-30T20:55:01Z"
+		},
+		{
+			"checksumSHA1": "SBBVYdLcocjdPzMWgDuR8vcOfDQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
-			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
+			"checksumSHA1": "+O6A945eTP9plLpkEMZB0lwBAcg=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
-			"checksumSHA1": "pkeoOfZpHRvFG/AOZeTf0lwtsFg=",
+			"checksumSHA1": "uRvmEPKcEdv7qc0Ep2zn0E3Xumc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
@@ -151,10 +169,22 @@
 			"revisionTime": "2017-11-22T02:06:34Z"
 		},
 		{
-			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
+			"checksumSHA1": "4dWtH/HkBpS7TnTf21+HOrE1zFc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
+			"revision": "81df2ff6701ff07d4f051fdc5c60220bbfbcafa0",
+			"revisionTime": "2018-07-30T20:55:01Z"
+		},
+		{
+			"checksumSHA1": "o+DFxugR5Cy/Wwlv7GSRRilTW4o=",
+			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
 			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
-			"revisionTime": "2017-11-22T02:06:34Z"
+			"revisionTime": "2018-07-30T20:55:01Z"
+		},
+		{
+			"checksumSHA1": "pMtjc3LhJ0Dk46ePV6MCIS0nIPs=",
+			"path": "github.com/aws/aws-sdk-go/service/ec2",
+			"revision": "a08a6c147b2563ad10342b88932b78247f45446b",
+			"revisionTime": "2018-07-30T20:55:01Z"
 		},
 		{
 			"checksumSHA1": "soLaAo4O4kxArCMP1r3ctgwhmC4=",
@@ -199,10 +229,10 @@
 			"revisionTime": "2017-03-07T19:08:18Z"
 		},
 		{
-			"checksumSHA1": "jK0knSGdB7hA/Pvc0mQBYkYxN/8=",
+			"checksumSHA1": "ENmi2SyGiR8a4ycVhs2gRdmWZg0=",
 			"path": "github.com/go-ini/ini",
-			"revision": "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a",
-			"revisionTime": "2017-11-19T05:34:21Z"
+			"revision": "d58d458bec3cb5adec4b7ddb41131855eac0b33f",
+			"revisionTime": "2018-07-23T10:44:51Z"
 		},
 		{
 			"checksumSHA1": "fSlTr0rwLji0DfsUOKYLkGUkiWo=",
@@ -211,10 +241,10 @@
 			"revisionTime": "2017-10-07T15:01:58Z"
 		},
 		{
-			"checksumSHA1": "Adg9cGxAPUBM/TQa7ukfYEoZJAA=",
+			"checksumSHA1": "blwbl9vPvRLtL5QlZgfpLvsFiZ4=",
 			"path": "github.com/jmespath/go-jmespath",
-			"revision": "dd801d4f4ce7ac746e7e7b4489d2fa600b3b096b",
-			"revisionTime": "2017-11-20T06:35:26Z"
+			"revision": "c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5",
+			"revisionTime": "2018-02-06T20:15:40Z"
 		},
 		{
 			"checksumSHA1": "0UY6Yp9cpQjofjSVJnZAwGxrdGY=",
@@ -355,7 +385,7 @@
 			"revisionTime": "2017-10-07T15:42:58Z"
 		},
 		{
-      "checksumSHA1": "Uv6a/M9wO8QyNfKOHuQIg1X03Fg=",
+			"checksumSHA1": "Uv6a/M9wO8QyNfKOHuQIg1X03Fg=",
 			"path": "gopkg.in/olivere/elastic.v5",
 			"revision": "2a08d39723b7f4df92b96e2dff891a60952714d6",
 			"revisionTime": "2017-09-26T20:05:24Z"


### PR DESCRIPTION
This PR will add support for EC2 Reports.

- These reports will let you see daily reports for EC2 instances with stats like CPU peak & average usage.
- An endpoint (`GET /ec2`) is available to get these reports. You can filter by account or select a timerange to have multiple reports.