### PR TITLE
Fixed billing mismatch numbers

### DIFF
--- a/costs/costs_route.go
+++ b/costs/costs_route.go
@@ -144,7 +144,7 @@ func getCostData(request *http.Request, a routes.Arguments) (int, interface{}) {
 	parsedParams := esQueryParams{
 		accountList:       []string{},
 		dateBegin:         a[costsQueryArgs[1]].(time.Time),
-		dateEnd:           a[costsQueryArgs[2]].(time.Time),
+		dateEnd:           a[costsQueryArgs[2]].(time.Time).Add(time.Hour*time.Duration(23) + time.Minute*time.Duration(59) + time.Second*time.Duration(59)),
 		aggregationParams: a[costsQueryArgs[3]].([]string),
 	}
 	if a[costsQueryArgs[0]] != nil {

--- a/costs/diff/diff_route.go
+++ b/costs/diff/diff_route.go
@@ -109,7 +109,7 @@ func getDiffData(request *http.Request, a routes.Arguments) (int, interface{}) {
 	parsedParams := esQueryParams{
 		accountList:       []string{},
 		dateBegin:         a[diffQueryArgs[1]].(time.Time),
-		dateEnd:           a[diffQueryArgs[2]].(time.Time),
+		dateEnd:           a[diffQueryArgs[2]].(time.Time).Add(time.Hour*time.Duration(23) + time.Minute*time.Duration(59) + time.Second*time.Duration(59)),
 		aggregationPeriod: a[diffQueryArgs[3]].(string),
 	}
 	if a[diffQueryArgs[0]] != nil {

--- a/s3/costs/s3_costs_route.go
+++ b/s3/costs/s3_costs_route.go
@@ -135,7 +135,7 @@ func getS3CostData(request *http.Request, a routes.Arguments) (int, interface{})
 	user := a[users.AuthenticatedUser].(users.User)
 	parsedParams := esQueryParams{
 		dateBegin:   a[routes.DateBeginQueryArg].(time.Time),
-		dateEnd:     a[routes.DateEndQueryArg].(time.Time),
+		dateEnd:     a[routes.DateEndQueryArg].(time.Time).Add(time.Hour*time.Duration(23) + time.Minute*time.Duration(59) + time.Second*time.Duration(59)),
 		accountList: []string{},
 	}
 	if a[awsAccountsQueryArg] != nil {


### PR DESCRIPTION
This PR sets the dateEnd parameter to the end of the day for all elasticsearch queries to avoid losing the billing data for the last day of the interval