### PR TITLE
make accounts parameters consistents accross all endpoints

### DIFF
--- a/aws/routes/routes.go
+++ b/aws/routes/routes.go
@@ -18,10 +18,10 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/trackit/trackit-server/aws"
 	"github.com/trackit/trackit-server/db"
 	"github.com/trackit/trackit-server/routes"
 	"github.com/trackit/trackit-server/users"
-	"github.com/trackit/trackit-server/aws"
 )
 
 // AwsAccountIdsOptionalQueryArg allows to get the AWS Account IDs in the URL
@@ -48,38 +48,38 @@ func init() {
 				routes.AwsAccountIdsOptionalQueryArg,
 				DetailedOptionalQueryArg,
 			},
-	),
+		),
 		http.MethodPost: routes.H(postAwsAccount).With(
-		users.RequireAuthenticatedUser{users.ViewerCannot},
-		routes.RequestContentType{"application/json"},
-		routes.RequestBody{postAwsAccountRequestBody{
-		RoleArn:  "arn:aws:iam::123456789012:role/example",
-		External: "LlzrwHeiM-SGKRLPgaGbeucx_CJC@QBl,_vOEF@o",
-		Pretty:   "My AWS account",
-	}},
-		routes.Documentation{
-		Summary:     "add an aws account",
-		Description: "Adds an AWS account to the user's list of accounts, validating it before succeeding.",
-	},
-	),
+			users.RequireAuthenticatedUser{users.ViewerCannot},
+			routes.RequestContentType{"application/json"},
+			routes.RequestBody{postAwsAccountRequestBody{
+				RoleArn:  "arn:aws:iam::123456789012:role/example",
+				External: "LlzrwHeiM-SGKRLPgaGbeucx_CJC@QBl,_vOEF@o",
+				Pretty:   "My AWS account",
+			}},
+			routes.Documentation{
+				Summary:     "add an aws account",
+				Description: "Adds an AWS account to the user's list of accounts, validating it before succeeding.",
+			},
+		),
 		http.MethodPatch: routes.H(patchAwsAccount).With(
-		users.RequireAuthenticatedUser{users.ViewerCannot},
-		routes.RequestContentType{"application/json"},
-		routes.QueryArgs{routes.AwsAccountIdQueryArg},
-		routes.Documentation{
-		Summary:     "edit an aws account",
-		Description: "Edits an AWS account from the user's list of accounts.",
-	},
-	),
+			users.RequireAuthenticatedUser{users.ViewerCannot},
+			routes.RequestContentType{"application/json"},
+			routes.QueryArgs{routes.AwsAccountIdQueryArg},
+			routes.Documentation{
+				Summary:     "edit an aws account",
+				Description: "Edits an AWS account from the user's list of accounts.",
+			},
+		),
 		http.MethodDelete: routes.H(deleteAwsAccount).With(
-		users.RequireAuthenticatedUser{users.ViewerCannot},
-		routes.QueryArgs{routes.AwsAccountIdQueryArg},
-		aws.RequireAwsAccountId{},
-		routes.Documentation{
-		Summary:     "delete an aws account",
-		Description: "Delete the aws account passed in the query args.",
-	},
-	),
+			users.RequireAuthenticatedUser{users.ViewerCannot},
+			routes.QueryArgs{routes.AwsAccountIdQueryArg},
+			aws.RequireAwsAccountId{},
+			routes.Documentation{
+				Summary:     "delete an aws account",
+				Description: "Delete the aws account passed in the query args.",
+			},
+		),
 	}.H().With(
 		db.RequestTransaction{db.Db},
 		routes.Documentation{

--- a/costs/costs_route.go
+++ b/costs/costs_route.go
@@ -55,13 +55,7 @@ type esQueryParams struct {
 
 // costQueryArgs allows to get required queryArgs params
 var costsQueryArgs = []routes.QueryArg{
-	// TODO (BREAKING CHANGE): replace by routes.AwsAccountsOptionalQueryArg
-	routes.QueryArg{
-		Name:        "accounts",
-		Description: "List of comma separated AWS accounts ids",
-		Type:        routes.QueryArgStringSlice{},
-		Optional:    true,
-	},
+	routes.AwsAccountsOptionalQueryArg,
 	routes.DateBeginQueryArg,
 	routes.DateEndQueryArg,
 	routes.QueryArg{

--- a/routes/commonQueryArgs.go
+++ b/routes/commonQueryArgs.go
@@ -15,25 +15,25 @@
 package routes
 
 var (
-	// AwsAccountIdsOptionalQueryArg allows to get the AWS Account IDs in the URL
-	// Parameters with routes.RequiredQueryArgs. This AWS Account IDs will be a
+	// AwsAccountIdsOptionalQueryArg allows to get the DB ids for AWS Accounts
+	// in the URL parameters with routes.RequiredQueryArgs. These IDs will be a
 	// slice of Uint stored in the routes.Arguments map with itself for key.
 	// AwsAccountIdsOptionalQueryArg is optional and will not panic if no query
 	// argument is found.
 	AwsAccountIdsOptionalQueryArg = QueryArg{
-		Name:        "aa",
+		Name:        "account-ids",
 		Type:        QueryArgIntSlice{},
-		Description: "The IDs for many AWS account.",
+		Description: "Comma separated DB IDs for many AWS account.",
 		Optional:    true,
 	}
 
-	// AwsAccountIdQueryArg allows to get the AWS Account ID in the URL Parameters
+	// AwsAccountIdQueryArg allows to get the DB id for an AWS Account in the URL Parameters
 	// with routes.RequiredQueryArgs. This AWS Account ID will be an Uint stored
 	// in the routes.Arguments map with itself for key.
 	AwsAccountIdQueryArg = QueryArg{
-		Name:        "aa",
+		Name:        "account-id",
 		Type:        QueryArgInt{},
-		Description: "The ID for an AWS account.",
+		Description: "The DB ID for an AWS account.",
 	}
 
 	// AwsAccountsOptionalQueryArg allows to get the AWS Accounts in the URL
@@ -42,9 +42,9 @@ var (
 	// AwsAccountsOptionalQueryArg is optional and will not panic if no query
 	// argument is found.
 	AwsAccountsOptionalQueryArg = QueryArg{
-		Name:        "aa",
+		Name:        "accounts",
 		Type:        QueryArgStringSlice{},
-		Description: "The IDs for many AWS account.",
+		Description: "Comma separated AWS account IDs.",
 		Optional:    true,
 	}
 
@@ -52,9 +52,9 @@ var (
 	// with routes.RequiredQueryArgs. This AWS Account will be a String stored
 	// in the routes.Arguments map with itself for key.
 	AwsAccountQueryArg = QueryArg{
-		Name:        "aa",
+		Name:        "account",
 		Type:        QueryArgString{},
-		Description: "The ID for an AWS account.",
+		Description: "AWS account ID.",
 	}
 
 	// BillPositoryQueryArg allows to get the bill repository ID in the URL Parameters
@@ -63,7 +63,7 @@ var (
 	BillPositoryQueryArg = QueryArg{
 		Name:        "br",
 		Type:        QueryArgInt{},
-		Description: "The ID for an AWS account.",
+		Description: "The ID for a bill repository.",
 	}
 
 	// DateBeginQueryArg allows to get the iso8601 begin date in the URL

--- a/s3/costs/s3_costs_route.go
+++ b/s3/costs/s3_costs_route.go
@@ -71,25 +71,12 @@ func init() {
 				Summary:     "get the s3 costs data",
 				Description: "Responds with cost data based on the queryparams passed to it",
 			},
-			routes.QueryArgs{awsAccountsQueryArg},
+			routes.QueryArgs{routes.AwsAccountsOptionalQueryArg},
 			routes.QueryArgs{routes.DateBeginQueryArg},
 			routes.QueryArgs{routes.DateEndQueryArg},
 		),
 	}.H().Register("/s3/costs")
 }
-
-var (
-	// awsAccountsQueryArg allows to get the AWS Account IDs in the URL
-	// Parameters with routes.QueryArgs. These AWS Account IDs will be a
-	// slice of Uint stored in the routes.Arguments map with itself for key.
-	// TODO (BREAKING CHANGE): replace by routes.AwsAccountsOptionalQueryArg
-	awsAccountsQueryArg = routes.QueryArg{
-		Name:        "aas",
-		Type:        routes.QueryArgStringSlice{},
-		Description: "The IDs for many AWS account.",
-		Optional:    true,
-	}
-)
 
 // makeElasticSearchRequest prepares and run the request to retrieve usage and cost
 // informations related to the queryDataType
@@ -138,8 +125,8 @@ func getS3CostData(request *http.Request, a routes.Arguments) (int, interface{})
 		dateEnd:     a[routes.DateEndQueryArg].(time.Time).Add(time.Hour*time.Duration(23) + time.Minute*time.Duration(59) + time.Second*time.Duration(59)),
 		accountList: []string{},
 	}
-	if a[awsAccountsQueryArg] != nil {
-		parsedParams.accountList = a[awsAccountsQueryArg].([]string)
+	if a[routes.AwsAccountsOptionalQueryArg] != nil {
+		parsedParams.accountList = a[routes.AwsAccountsOptionalQueryArg].([]string)
 	}
 	var err error
 	var returnCode int


### PR DESCRIPTION
This PR improves the naming of the url parameters and make them consistent on all endpoints

PLEASE DO NOT DEPLOY BEFORE THE FRONT END IS READY

new param names:
account-id/account-ids: integer, id in database
account/accounts: string, aws account id

format:
endpoint: previous_param -> new_param

GET /aws: aa -> account-ids
PATCH /aws: aa -> account-id
DELETE /aws: aa -> account-id

GET /aws/billrepository: aa -> account-id
POST /aws/billrepository: aa -> account-id
PATCH /aws/billrepository: aa -> account-id
DELETE /aws/billrepository: aa -> account-id

GET /reports: aa -> account-id

GET /report: aa -> account-id

GET /costs/anomalies: aa -> accounts

GET /costs/diff: aa -> accounts

GET /costs/tags/values: aa -> accounts

GET /costs/tags/keys: aa -> accounts

GET /s3/costs: aas -> accounts

GET /ec2: aa -> account (will be changed to accounts when multiple accounts support is added)

GET /rds: aa -> account (will be changed to accounts when multiple accounts support is added)