### PR TITLE
[FIX] Can't connect to a recently created account

### DIFF
--- a/users/users.go
+++ b/users/users.go
@@ -49,6 +49,7 @@ func CreateUserWithPassword(ctx context.Context, db models.XODB, email string, p
 	dbUser := models.User{
 		Email: email,
 		AwsCustomerIdentifier: customerIdentifier,
+		AwsCustomerEntitlement: true,
 	}
 	auth, err := getPasswordHash(password)
 	if err != nil {


### PR DESCRIPTION
We can't connect to an account that we just created because a value in databse is not good. This update should fix it.