### PR TITLE
[Fix] Tags products limit

### DIFF
--- a/costs/tags/tags_values.go
+++ b/costs/tags/tags_values.go
@@ -123,7 +123,7 @@ func makeElasticSearchRequestForTagsValues(ctx context.Context, params tagsValue
 		SubAggregation("keys",    elastic.NewTermsAggregation().Field("tags.key").
 		SubAggregation("tags",    elastic.NewTermsAggregation().Field("tags.tag").
 		SubAggregation("rev",     elastic.NewReverseNestedAggregation().
-		SubAggregation("filter",  elastic.NewTermsAggregation().Field(filter).
+		SubAggregation("filter",  elastic.NewTermsAggregation().Field(filter).Size(0x7FFFFFFF).
 		SubAggregation("cost",    elastic.NewSumAggregation().Field("unblendedCost")))))))
 	res, err := search.Do(ctx)
 	if err != nil {


### PR DESCRIPTION
All products were not searched on the tags route. This update fix it.