### PR TITLE
Fix account sharing to prevent global access

### DIFF
--- a/es/accountsSharing.go
+++ b/es/accountsSharing.go
@@ -104,6 +104,10 @@ func getAllAccountsAndIndexes(user users.User, tx *sql.Tx, indexPrefix string) (
 			accountsAndIndexes.addIndex(IndexNameForUserId(sharedAccount.OwnerID, indexPrefix))
 		}
 	}
+	// If no indexes where found, return an error to prevent giving access to all indexes
+	if len(accountsAndIndexes.Indexes) == 0 {
+		return accountsAndIndexes, http.StatusBadRequest, fmt.Errorf("No aws account found")
+	}
 	return accountsAndIndexes, http.StatusOK, nil
 }
 


### PR DESCRIPTION
This PR returns an error when no index is found during account sharing selection to prevent giving global access to ES