### PR TITLE
Fix taxes billing

### DIFF
--- a/aws/s3/ingestBills.go
+++ b/aws/s3/ingestBills.go
@@ -162,6 +162,10 @@ func getBulkProcessor(ctx context.Context) (*elastic.BulkProcessor, error) {
 func ingestLineItems(ctx context.Context, bp *elastic.BulkProcessor, index string, br BillRepository) OnLineItem {
 	return func(li LineItem, ok bool) {
 		if ok {
+			if li.LineItemType == "Tax" {
+				li.AvailabilityZone = "taxes"
+				li.Region = "taxes"
+			}
 			li.BillRepositoryId = br.Id
 			li = extractTags(li)
 			rq := elastic.NewBulkIndexRequest()
@@ -182,7 +186,7 @@ func ingestLineItems(ctx context.Context, bp *elastic.BulkProcessor, index strin
 // manifests starting after a given date.
 func manifestsModifiedAfter(t time.Time) ManifestPredicate {
 	return func(m manifest, oneMonthBefore bool) bool {
-		if (oneMonthBefore) {
+		if oneMonthBefore {
 			if time.Time(m.LastModified).AddDate(0, 1, 0).After(t) {
 				return true
 			} else {

--- a/aws/s3/mappings.go
+++ b/aws/s3/mappings.go
@@ -42,7 +42,7 @@ func init() {
 const TemplateLineItem = `
 {
 	"template": "*-lineitems",
-	"version": 7,
+	"version": 8,
 	"mappings": {
 		"lineitem": {
 			"properties": {
@@ -62,6 +62,10 @@ const TemplateLineItem = `
 					"norms": false
 				},
 				"usageAccountId": {
+					"type": "keyword",
+					"norms": false
+				},
+				"lineItemType": {
 					"type": "keyword",
 					"norms": false
 				},
@@ -104,6 +108,10 @@ const TemplateLineItem = `
 				"unblendedCost": {
 					"type": "float",
 					"index": false
+				},
+				"taxType": {
+					"type": "keyword",
+					"norms": false
 				},
 				"usageStartDate": {
 					"type": "date"

--- a/aws/s3/readBills.go
+++ b/aws/s3/readBills.go
@@ -32,8 +32,8 @@ import (
 
 	taws "github.com/trackit/trackit-server/aws"
 	"github.com/trackit/trackit-server/config"
-	"github.com/trackit/trackit-server/util/csv"
 	"github.com/trackit/trackit-server/es"
+	"github.com/trackit/trackit-server/util/csv"
 )
 
 const (
@@ -101,6 +101,7 @@ type LineItem struct {
 	BillingPeriodStart string            `csv:"bill/BillingPeriodStartDate"  json:"-"`
 	BillingPeriodEnd   string            `csv:"bill/BillingPeriodEndDate"    json:"-"`
 	UsageAccountId     string            `csv:"lineItem/UsageAccountId"      json:"usageAccountId"`
+	LineItemType       string            `csv:"lineItem/LineItemType"        json:"lineItemType"`
 	UsageStartDate     string            `csv:"lineItem/UsageStartDate"      json:"usageStartDate"`
 	UsageEndDate       string            `csv:"lineItem/UsageEndDate"        json:"usageEndDate""`
 	ProductCode        string            `csv:"lineItem/ProductCode"         json:"productCode"`
@@ -113,6 +114,7 @@ type LineItem struct {
 	ServiceCode        string            `csv:"product/servicecode"          json:"serviceCode"`
 	CurrencyCode       string            `csv:"lineItem/CurrencyCode"        json:"currencyCode"`
 	UnblendedCost      string            `csv:"lineItem/UnblendedCost"       json:"unblendedCost"`
+	TaxType            string            `csv:"lineItem/TaxType"             json:"taxType"`
 	Any                map[string]string `csv:",any"                         json:"-"`
 	Tags               []LineItemTags    `csv:"-"                            json:"tags,omitempty"`
 }
@@ -214,7 +216,7 @@ func readBill(ctx context.Context, cancel context.CancelFunc, reader io.ReadClos
 		defer close(out)
 		csvDecoder := csv.NewDecoder(reader)
 		for r := range records(ctx, &csvDecoder) {
-			if (mp(m, false) || r.InvoiceId == "") {
+			if mp(m, false) || r.InvoiceId == "" {
 				out <- r
 			}
 		}


### PR DESCRIPTION
This PR improves the way we handle taxes.
We put "taxes" in the region and availability zone so that when we do an aggregation they appear in a "taxes" category instead of "".
We also save the line item type and tax type that may be useful later