### PR TITLE
Update policies to handle future RI features

### DIFF
--- a/policies/all_policies.json
+++ b/policies/all_policies.json
@@ -21,7 +21,10 @@
                 "rds:DescribeDBInstances",
                 "cloudwatch:GetMetricStatistics",
                 "ec2:DescribeRegions",
-                "ec2:DescribeInstances"
+                "ec2:DescribeInstances",
+                "ec2:DescribeReservedInstancesListings",
+                "ec2:DescribeReservedInstancesModifications",
+                "ec2:DescribeReservedInstancesOfferings"
             ],
             "Resource": "*"
         }

--- a/policies/tool_policies/monitor_ressources.json
+++ b/policies/tool_policies/monitor_ressources.json
@@ -7,7 +7,10 @@
         "rds:DescribeDBInstances",
         "cloudwatch:GetMetricStatistics",
         "ec2:DescribeRegions",
-        "ec2:DescribeInstances"
+        "ec2:DescribeInstances",
+        "ec2:DescribeReservedInstancesListings",
+        "ec2:DescribeReservedInstancesModifications",
+        "ec2:DescribeReservedInstancesOfferings"
       ],
       "Effect": "Allow",
       "Resource": "*"


### PR DESCRIPTION
This updates the policy files to handle future RI features based on the permissions needed by our aws-cost-report python tool.