### PR TITLE
[FIX] Change format response for aws account

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -37,7 +37,7 @@ type AwsAccount struct {
 	RoleArn        string `json:"roleArn"`
 	External       string `json:"-"`
 	Payer          bool   `json:"payer"`
-	UserPermission int    `json:permissionLevel`
+	UserPermission int    `json:"permissionLevel"`
 }
 
 const (


### PR DESCRIPTION
This PR correct response format for GET request on `/aws`
`UserPermission` is now `permissionLevel`.