### PR TITLE
[TRAC-973] Reworkunused EC2 endpoint

### DIFF
--- a/ec2/ec2_route.go
+++ b/ec2/ec2_route.go
@@ -16,7 +16,6 @@ package ec2
 
 import (
 	"time"
-	"errors"
 	"net/http"
 	"database/sql"
 
@@ -39,7 +38,6 @@ type (
 		indexList   []string
 		date        time.Time
 		count       int
-		by          string
 	}
 )
 
@@ -58,12 +56,6 @@ var (
 			Name:        "count",
 			Type:        routes.QueryArgInt{},
 			Description: "Number of element in the response, all if not precised or negative",
-			Optional:    true,
-		},
-		routes.QueryArg{
-			Name:        "by",
-			Type:        routes.QueryArgString{},
-			Description: "Element choose to sort unused data, (cpu, network, io), default cpu",
 			Optional:    true,
 		},
 	}
@@ -121,19 +113,12 @@ func getEc2UnusedInstances(request *http.Request, a routes.Arguments) (int, inte
 		accountList: []string{},
 		date:        a[ec2UnusedQueryArgs[1]].(time.Time),
 		count:       -1,
-		by:          "cpu",
 	}
 	if a[ec2UnusedQueryArgs[0]] != nil {
 		parsedParams.accountList = a[ec2UnusedQueryArgs[0]].([]string)
 	}
 	if a[ec2UnusedQueryArgs[2]] != nil {
 		parsedParams.count = a[ec2UnusedQueryArgs[2]].(int)
-	}
-	if a[ec2UnusedQueryArgs[3]] != nil {
-		parsedParams.by = a[ec2UnusedQueryArgs[3]].(string)
-		if parsedParams.by != "cpu" && parsedParams.by != "io" && parsedParams.by != "network" {
-			return http.StatusBadRequest, errors.New("bad argument for the query arg 'by'")
-		}
 	}
 	returnCode, report, err := getEc2UnusedData(request, parsedParams, user, tx)
 	if err != nil {

--- a/ec2/get_ec2_data.go
+++ b/ec2/get_ec2_data.go
@@ -140,7 +140,7 @@ func getEc2Data(request *http.Request, parsedParams ec2QueryParams, user users.U
 		return returnCode, nil, err
 	}
 	if searchResult.Hits.TotalHits > 0 {
-		res, err := prepareResponseEc2History(request.Context(), searchResult)
+		res, err := prepareResponseEc2Monthly(request.Context(), searchResult)
 		if err != nil {
 			return http.StatusInternalServerError, nil, err
 		}

--- a/ec2/prepare_response.go
+++ b/ec2/prepare_response.go
@@ -133,8 +133,8 @@ func prepareResponseEc2(ctx context.Context, resEc2 *elastic.SearchResult, resCo
 	return reports, nil
 }
 
-// prepareResponseEc2History parses the results from elasticsearch and returns the EC2 usage report
-func prepareResponseEc2History(ctx context.Context, resEc2 *elastic.SearchResult) ([]Report, error) {
+// prepareResponseEc2Monthly parses the results from elasticsearch and returns the EC2 usage report
+func prepareResponseEc2Monthly(ctx context.Context, resEc2 *elastic.SearchResult) ([]Report, error) {
 	response := ResponseEc2{}
 	reports := []Report{}
 	err := json.Unmarshal(*resEc2.Aggregations["top_reports"], &response.TopReports)
@@ -149,73 +149,15 @@ func prepareResponseEc2History(ctx context.Context, resEc2 *elastic.SearchResult
 	return reports, nil
 }
 
-// compareInstanceCpu compares the Cpu average of two ec2 instances
-// If inst1 is lower it returns 1, if inst2 is lower it returns -1, if they are equals it returns 0
-func compareInstanceCpu(inst1, inst2 Instance) int {
-	if inst1.CpuAverage < inst2.CpuAverage {
-		return 1
-	} else if inst1.CpuAverage > inst2.CpuAverage {
-		return -1
-	} else {
-		return 0
+func isInstanceUnused(instance Instance) bool {
+	average := instance.CpuAverage
+	peak    := instance.CpuPeak
+	if peak >= 60.0 {
+		return false
+	} else if average >= 10.0 {
+		return false
 	}
-}
-
-// compareInstanceNetwork compares the network in and out of two ec2 instances
-// If inst1 is lower it returns 1, if inst2 is lower it returns -1, if they are equals it returns 0
-func compareInstanceNetwork(inst1, inst2 Instance) int {
-	network1 := inst1.NetworkIn
-	network1 += inst1.NetworkOut
-	network2 := inst2.NetworkIn
-	network2 += inst2.NetworkOut
-	if network1 < network2 {
-		return 1
-	} else if network1 > network2 {
-		return -1
-	} else {
-		return 0
-	}
-}
-
-// compareInstanceIo compares the IO read and write of two ec2 instances
-// If inst1 is lower it returns 1, if inst2 is lower it returns -1, if they are equals it returns 0
-func compareInstanceIo(inst1, inst2 Instance) int {
-	var io1 float64 = 0
-	var io2 float64 = 0
-	for _, read := range inst1.IORead {
-		io1 += read
-	}
-	for _, write := range inst1.IOWrite {
-		io1 += write
-	}
-	for _, read := range inst2.IORead {
-		io2 += read
-	}
-	for _, write := range inst2.IOWrite {
-		io2 += write
-	}
-	if io1 < io2 {
-		return 1
-	} else if io1 > io2 {
-		return -1
-	} else {
-		return 0
-	}
-}
-
-// compareInstance compares two ec2 instances depending on "by" parameter
-// If inst1 is lower it returns 1, if inst2 is lower it returns -1, if they are equals it returns 0
-func compareInstance(inst1, inst2 Instance, by string) int {
-	switch by {
-	case "cpu":
-		return compareInstanceCpu(inst1, inst2)
-	case "network":
-		return compareInstanceNetwork(inst1, inst2)
-	case "io":
-		return compareInstanceIo(inst1, inst2)
-	default:
-		return 0
-	}
+	return true
 }
 
 // prepareResponseEc2Unused filter reports to get the top instances
@@ -223,11 +165,13 @@ func prepareResponseEc2Unused(params ec2UnusedQueryParams, reports []Report) (in
 	instances := []Instance{}
 	for _, report := range reports {
 		for _, instance := range report.Instances {
-			instances = append(instances, instance)
+			if isInstanceUnused(instance) {
+				instances = append(instances, instance)
+			}
 		}
 	}
 	for i := 0; i < len(instances) - 1; i++ {
-		if diff := compareInstance(instances[i], instances[i + 1], params.by); diff == -1 {
+		if instances[i].Cost < instances[i + 1].Cost {
 			tmp := instances[i]
 			instances[i] = instances[i + 1]
 			instances[i + 1] = tmp


### PR DESCRIPTION
### The endpoint `/ec2/unused`:

- Doesn't take the query param `by` anymore
- Orders instances by cost
- Remove from the array used instances (based now on CPU average and peak, to be tested and improved later if too strict or not enough)