### PR TITLE
Scheduling improvement: remove grace_update fields

### DIFF
--- a/db/migration/0020_improve_scheduling.sql
+++ b/db/migration/0020_improve_scheduling.sql
@@ -1,0 +1,28 @@
+--   Copyright 2018 MSolution.IO
+--
+--   Licensed under the Apache License, Version 2.0 (the "License");
+--   you may not use this file except in compliance with the License.
+--   You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--   Unless required by applicable law or agreed to in writing, software
+--   distributed under the License is distributed on an "AS IS" BASIS,
+--   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--   See the License for the specific language governing permissions and
+--   limitations under the License.
+
+ALTER TABLE aws_bill_repository DROP COLUMN grace_update;
+ALTER TABLE aws_account DROP COLUMN grace_update, DROP COLUMN grace_update_plugins;
+
+CREATE OR REPLACE VIEW aws_bill_repository_due_update AS
+	SELECT * FROM aws_bill_repository WHERE next_update <= NOW()
+;
+
+CREATE OR REPLACE VIEW aws_account_due_update AS
+	SELECT * FROM aws_account WHERE next_update <= NOW()
+;
+
+CREATE OR REPLACE VIEW aws_account_plugins_due_update AS
+	SELECT * FROM aws_account WHERE next_update_plugins <= NOW()
+;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -450,3 +450,32 @@ ALTER TABLE user ADD next_update_entitlement DATETIME NOT NULL DEFAULT "1970-01-
 CREATE VIEW user_entitlement_due_update AS
 	SELECT * FROM user WHERE next_update_entitlement <= NOW()
 ;
+
+--   Copyright 2018 MSolution.IO
+--
+--   Licensed under the Apache License, Version 2.0 (the "License");
+--   you may not use this file except in compliance with the License.
+--   You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--   Unless required by applicable law or agreed to in writing, software
+--   distributed under the License is distributed on an "AS IS" BASIS,
+--   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--   See the License for the specific language governing permissions and
+--   limitations under the License.
+
+ALTER TABLE aws_bill_repository DROP COLUMN grace_update;
+ALTER TABLE aws_account DROP COLUMN grace_update, DROP COLUMN grace_update_plugins;
+
+CREATE OR REPLACE VIEW aws_bill_repository_due_update AS
+	SELECT * FROM aws_bill_repository WHERE next_update <= NOW()
+;
+
+CREATE OR REPLACE VIEW aws_account_due_update AS
+	SELECT * FROM aws_account WHERE next_update <= NOW()
+;
+
+CREATE OR REPLACE VIEW aws_account_plugins_due_update AS
+	SELECT * FROM aws_account WHERE next_update_plugins <= NOW()
+;

--- a/models/awsaccount.go
+++ b/models/awsaccount.go
@@ -19,7 +19,7 @@ package models
 func AwsAccounts(db XODB) ([]*AwsAccount, error) {
 	var err error
 	const sqlstr = `SELECT ` +
-		`id, user_id, pretty, role_arn, external, next_update, grace_update ` +
+		`id, user_id, pretty, role_arn, external, next_update ` +
 		`FROM trackit.aws_account`
 	XOLog(sqlstr)
 	q, err := db.Query(sqlstr)
@@ -32,7 +32,7 @@ func AwsAccounts(db XODB) ([]*AwsAccount, error) {
 		aa := AwsAccount{
 			_exists: true,
 		}
-		err = q.Scan(&aa.ID, &aa.UserID, &aa.Pretty, &aa.RoleArn, &aa.External, &aa.NextUpdate, &aa.GraceUpdate)
+		err = q.Scan(&aa.ID, &aa.UserID, &aa.Pretty, &aa.RoleArn, &aa.External, &aa.NextUpdate)
 		if err != nil {
 			return nil, err
 		}

--- a/models/awsaccount.xo.go
+++ b/models/awsaccount.xo.go
@@ -10,14 +10,14 @@ import (
 
 // AwsAccount represents a row from 'trackit.aws_account'.
 type AwsAccount struct {
-	ID          int       `json:"id"`           // id
-	UserID      int       `json:"user_id"`      // user_id
-	Pretty      string    `json:"pretty"`       // pretty
-	RoleArn     string    `json:"role_arn"`     // role_arn
-	External    string    `json:"external"`     // external
-	NextUpdate  time.Time `json:"next_update"`  // next_update
-	GraceUpdate time.Time `json:"grace_update"` // grace_update
-	Payer       bool      `json:"payer"`        // payer
+	ID                int       `json:"id"`                  // id
+	UserID            int       `json:"user_id"`             // user_id
+	Pretty            string    `json:"pretty"`              // pretty
+	RoleArn           string    `json:"role_arn"`            // role_arn
+	External          string    `json:"external"`            // external
+	NextUpdate        time.Time `json:"next_update"`         // next_update
+	Payer             bool      `json:"payer"`               // payer
+	NextUpdatePlugins time.Time `json:"next_update_plugins"` // next_update_plugins
 
 	// xo fields
 	_exists, _deleted bool
@@ -44,14 +44,14 @@ func (aa *AwsAccount) Insert(db XODB) error {
 
 	// sql insert query, primary key provided by autoincrement
 	const sqlstr = `INSERT INTO trackit.aws_account (` +
-		`user_id, pretty, role_arn, external, next_update, grace_update, payer` +
+		`user_id, pretty, role_arn, external, next_update, payer, next_update_plugins` +
 		`) VALUES (` +
 		`?, ?, ?, ?, ?, ?, ?` +
 		`)`
 
 	// run query
-	XOLog(sqlstr, aa.UserID, aa.Pretty, aa.RoleArn, aa.External, aa.NextUpdate, aa.GraceUpdate, aa.Payer)
-	res, err := db.Exec(sqlstr, aa.UserID, aa.Pretty, aa.RoleArn, aa.External, aa.NextUpdate, aa.GraceUpdate, aa.Payer)
+	XOLog(sqlstr, aa.UserID, aa.Pretty, aa.RoleArn, aa.External, aa.NextUpdate, aa.Payer, aa.NextUpdatePlugins)
+	res, err := db.Exec(sqlstr, aa.UserID, aa.Pretty, aa.RoleArn, aa.External, aa.NextUpdate, aa.Payer, aa.NextUpdatePlugins)
 	if err != nil {
 		return err
 	}
@@ -85,12 +85,12 @@ func (aa *AwsAccount) Update(db XODB) error {
 
 	// sql query
 	const sqlstr = `UPDATE trackit.aws_account SET ` +
-		`user_id = ?, pretty = ?, role_arn = ?, external = ?, next_update = ?, grace_update = ?, payer = ?` +
+		`user_id = ?, pretty = ?, role_arn = ?, external = ?, next_update = ?, payer = ?, next_update_plugins = ?` +
 		` WHERE id = ?`
 
 	// run query
-	XOLog(sqlstr, aa.UserID, aa.Pretty, aa.RoleArn, aa.External, aa.NextUpdate, aa.GraceUpdate, aa.Payer, aa.ID)
-	_, err = db.Exec(sqlstr, aa.UserID, aa.Pretty, aa.RoleArn, aa.External, aa.NextUpdate, aa.GraceUpdate, aa.Payer, aa.ID)
+	XOLog(sqlstr, aa.UserID, aa.Pretty, aa.RoleArn, aa.External, aa.NextUpdate, aa.Payer, aa.NextUpdatePlugins, aa.ID)
+	_, err = db.Exec(sqlstr, aa.UserID, aa.Pretty, aa.RoleArn, aa.External, aa.NextUpdate, aa.Payer, aa.NextUpdatePlugins, aa.ID)
 	return err
 }
 
@@ -148,7 +148,7 @@ func AwsAccountByID(db XODB, id int) (*AwsAccount, error) {
 
 	// sql query
 	const sqlstr = `SELECT ` +
-		`id, user_id, pretty, role_arn, external, next_update, grace_update, payer ` +
+		`id, user_id, pretty, role_arn, external, next_update, payer, next_update_plugins ` +
 		`FROM trackit.aws_account ` +
 		`WHERE id = ?`
 
@@ -158,7 +158,7 @@ func AwsAccountByID(db XODB, id int) (*AwsAccount, error) {
 		_exists: true,
 	}
 
-	err = db.QueryRow(sqlstr, id).Scan(&aa.ID, &aa.UserID, &aa.Pretty, &aa.RoleArn, &aa.External, &aa.NextUpdate, &aa.GraceUpdate, &aa.Payer)
+	err = db.QueryRow(sqlstr, id).Scan(&aa.ID, &aa.UserID, &aa.Pretty, &aa.RoleArn, &aa.External, &aa.NextUpdate, &aa.Payer, &aa.NextUpdatePlugins)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func AwsAccountsByUserID(db XODB, userID int) ([]*AwsAccount, error) {
 
 	// sql query
 	const sqlstr = `SELECT ` +
-		`id, user_id, pretty, role_arn, external, next_update, grace_update, payer ` +
+		`id, user_id, pretty, role_arn, external, next_update, payer, next_update_plugins ` +
 		`FROM trackit.aws_account ` +
 		`WHERE user_id = ?`
 
@@ -194,7 +194,7 @@ func AwsAccountsByUserID(db XODB, userID int) ([]*AwsAccount, error) {
 		}
 
 		// scan
-		err = q.Scan(&aa.ID, &aa.UserID, &aa.Pretty, &aa.RoleArn, &aa.External, &aa.NextUpdate, &aa.GraceUpdate, &aa.Payer)
+		err = q.Scan(&aa.ID, &aa.UserID, &aa.Pretty, &aa.RoleArn, &aa.External, &aa.NextUpdate, &aa.Payer, &aa.NextUpdatePlugins)
 		if err != nil {
 			return nil, err
 		}

--- a/models/awsaccountdueupdate.xo.go
+++ b/models/awsaccountdueupdate.xo.go
@@ -9,11 +9,12 @@ import (
 
 // AwsAccountDueUpdate represents a row from 'trackit.aws_account_due_update'.
 type AwsAccountDueUpdate struct {
-	ID          int       `json:"id"`           // id
-	UserID      int       `json:"user_id"`      // user_id
-	Pretty      string    `json:"pretty"`       // pretty
-	RoleArn     string    `json:"role_arn"`     // role_arn
-	External    string    `json:"external"`     // external
-	NextUpdate  time.Time `json:"next_update"`  // next_update
-	GraceUpdate time.Time `json:"grace_update"` // grace_update
+	ID                int       `json:"id"`                  // id
+	UserID            int       `json:"user_id"`             // user_id
+	Pretty            string    `json:"pretty"`              // pretty
+	RoleArn           string    `json:"role_arn"`            // role_arn
+	External          string    `json:"external"`            // external
+	NextUpdate        time.Time `json:"next_update"`         // next_update
+	Payer             bool      `json:"payer"`               // payer
+	NextUpdatePlugins time.Time `json:"next_update_plugins"` // next_update_plugins
 }

--- a/models/awsbillrepository.xo.go
+++ b/models/awsbillrepository.xo.go
@@ -17,7 +17,6 @@ type AwsBillRepository struct {
 	LastImportedManifest time.Time `json:"last_imported_manifest"` // last_imported_manifest
 	NextUpdate           time.Time `json:"next_update"`            // next_update
 	Error                string    `json:"error"`                  // error
-	GraceUpdate          time.Time `json:"grace_update"`           // grace_update
 
 	// xo fields
 	_exists, _deleted bool
@@ -44,14 +43,14 @@ func (abr *AwsBillRepository) Insert(db XODB) error {
 
 	// sql insert query, primary key provided by autoincrement
 	const sqlstr = `INSERT INTO trackit.aws_bill_repository (` +
-		`aws_account_id, bucket, prefix, last_imported_manifest, next_update, error, grace_update` +
+		`aws_account_id, bucket, prefix, last_imported_manifest, next_update, error` +
 		`) VALUES (` +
-		`?, ?, ?, ?, ?, ?, ?` +
+		`?, ?, ?, ?, ?, ?` +
 		`)`
 
 	// run query
-	XOLog(sqlstr, abr.AwsAccountID, abr.Bucket, abr.Prefix, abr.LastImportedManifest, abr.NextUpdate, abr.Error, abr.GraceUpdate)
-	res, err := db.Exec(sqlstr, abr.AwsAccountID, abr.Bucket, abr.Prefix, abr.LastImportedManifest, abr.NextUpdate, abr.Error, abr.GraceUpdate)
+	XOLog(sqlstr, abr.AwsAccountID, abr.Bucket, abr.Prefix, abr.LastImportedManifest, abr.NextUpdate, abr.Error)
+	res, err := db.Exec(sqlstr, abr.AwsAccountID, abr.Bucket, abr.Prefix, abr.LastImportedManifest, abr.NextUpdate, abr.Error)
 	if err != nil {
 		return err
 	}
@@ -85,12 +84,12 @@ func (abr *AwsBillRepository) Update(db XODB) error {
 
 	// sql query
 	const sqlstr = `UPDATE trackit.aws_bill_repository SET ` +
-		`aws_account_id = ?, bucket = ?, prefix = ?, last_imported_manifest = ?, next_update = ?, error = ?, grace_update = ?` +
+		`aws_account_id = ?, bucket = ?, prefix = ?, last_imported_manifest = ?, next_update = ?, error = ?` +
 		` WHERE id = ?`
 
 	// run query
-	XOLog(sqlstr, abr.AwsAccountID, abr.Bucket, abr.Prefix, abr.LastImportedManifest, abr.NextUpdate, abr.Error, abr.GraceUpdate, abr.ID)
-	_, err = db.Exec(sqlstr, abr.AwsAccountID, abr.Bucket, abr.Prefix, abr.LastImportedManifest, abr.NextUpdate, abr.Error, abr.GraceUpdate, abr.ID)
+	XOLog(sqlstr, abr.AwsAccountID, abr.Bucket, abr.Prefix, abr.LastImportedManifest, abr.NextUpdate, abr.Error, abr.ID)
+	_, err = db.Exec(sqlstr, abr.AwsAccountID, abr.Bucket, abr.Prefix, abr.LastImportedManifest, abr.NextUpdate, abr.Error, abr.ID)
 	return err
 }
 
@@ -148,7 +147,7 @@ func AwsBillRepositoryByID(db XODB, id int) (*AwsBillRepository, error) {
 
 	// sql query
 	const sqlstr = `SELECT ` +
-		`id, aws_account_id, bucket, prefix, last_imported_manifest, next_update, error, grace_update ` +
+		`id, aws_account_id, bucket, prefix, last_imported_manifest, next_update, error ` +
 		`FROM trackit.aws_bill_repository ` +
 		`WHERE id = ?`
 
@@ -158,7 +157,7 @@ func AwsBillRepositoryByID(db XODB, id int) (*AwsBillRepository, error) {
 		_exists: true,
 	}
 
-	err = db.QueryRow(sqlstr, id).Scan(&abr.ID, &abr.AwsAccountID, &abr.Bucket, &abr.Prefix, &abr.LastImportedManifest, &abr.NextUpdate, &abr.Error, &abr.GraceUpdate)
+	err = db.QueryRow(sqlstr, id).Scan(&abr.ID, &abr.AwsAccountID, &abr.Bucket, &abr.Prefix, &abr.LastImportedManifest, &abr.NextUpdate, &abr.Error)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +173,7 @@ func AwsBillRepositoriesByAwsAccountID(db XODB, awsAccountID int) ([]*AwsBillRep
 
 	// sql query
 	const sqlstr = `SELECT ` +
-		`id, aws_account_id, bucket, prefix, last_imported_manifest, next_update, error, grace_update ` +
+		`id, aws_account_id, bucket, prefix, last_imported_manifest, next_update, error ` +
 		`FROM trackit.aws_bill_repository ` +
 		`WHERE aws_account_id = ?`
 
@@ -194,7 +193,7 @@ func AwsBillRepositoriesByAwsAccountID(db XODB, awsAccountID int) ([]*AwsBillRep
 		}
 
 		// scan
-		err = q.Scan(&abr.ID, &abr.AwsAccountID, &abr.Bucket, &abr.Prefix, &abr.LastImportedManifest, &abr.NextUpdate, &abr.Error, &abr.GraceUpdate)
+		err = q.Scan(&abr.ID, &abr.AwsAccountID, &abr.Bucket, &abr.Prefix, &abr.LastImportedManifest, &abr.NextUpdate, &abr.Error)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR is part of the scheduling system improvements to avoid the current issue with jobs being stacked and creating queues of 1000+ jobs

It removes the grace_update* fields to base the scheduling only on the next_update* fields:

1: The scheduler (on another repository) schedules a processing when next_update < now, then sets the next_update 72 hours in the future.
By setting the next_update to 72 hours in the future when scheduling we prevent the jobs to be stacked, because it is unlikely that a job will take more than 72 hours to be processed.

2: The task is executed and once the processing job is done it sets the next_update to the actual time we want to process it next, which is 6 hours (billings) / 24 hours (accounts, plugins) in the future.