### PR TITLE
[FIX] Number of tags in response

### DIFF
--- a/costs/tags/tags.go
+++ b/costs/tags/tags.go
@@ -132,8 +132,8 @@ func getTagsKeys(request *http.Request, a routes.Arguments) (int, interface{}) {
 	parsedParams := tagsKeysQueryParams{
 		AccountList: []string{},
 		IndexList:   []string{},
-		DateBegin:   a[tagsValuesQueryArgs[1]].(time.Time),
-		DateEnd:     a[tagsValuesQueryArgs[2]].(time.Time).Add(time.Hour*time.Duration(23) + time.Minute*time.Duration(59) + time.Second*time.Duration(59)),
+		DateBegin:   a[tagsKeysQueryArgs[1]].(time.Time),
+		DateEnd:     a[tagsKeysQueryArgs[2]].(time.Time).Add(time.Hour*time.Duration(23) + time.Minute*time.Duration(59) + time.Second*time.Duration(59)),
 	}
 	if a[tagsKeysQueryArgs[0]] != nil {
 		parsedParams.AccountList = a[tagsKeysQueryArgs[0]].([]string)

--- a/costs/tags/tags_keys.go
+++ b/costs/tags/tags_keys.go
@@ -41,6 +41,8 @@ type (
 	TagsKeys []string
 )
 
+const maxAggregationSize = 0x7FFFFFFF
+
 // getTagsKeysWithParsedParams will parse the data from ElasticSearch and return it
 func getTagsKeysWithParsedParams(ctx context.Context, params tagsKeysQueryParams) (int, interface{}) {
 	var typedDocument esTagsKeysResult
@@ -77,7 +79,7 @@ func makeElasticSearchRequestForTagsKeys(ctx context.Context, params tagsKeysQue
 	index := strings.Join(params.IndexList, ",")
 	search := client.Search().Index(index).Size(0).Query(query)
 	search.Aggregation("data", elastic.NewNestedAggregation().Path("tags").
-		SubAggregation("keys", elastic.NewTermsAggregation().Field("tags.key")))
+		SubAggregation("keys", elastic.NewTermsAggregation().Field("tags.key").Size(maxAggregationSize)))
 	res, err := search.Do(ctx)
 	if err != nil {
 		if elastic.IsNotFound(err) {

--- a/costs/tags/tags_values.go
+++ b/costs/tags/tags_values.go
@@ -127,7 +127,7 @@ func makeElasticSearchRequestForTagsValues(ctx context.Context, params tagsValue
 	query := getTagsValuesQuery(params)
 	index := strings.Join(params.IndexList, ",")
 	aggregation := elastic.NewReverseNestedAggregation().
-		SubAggregation("filter", elastic.NewTermsAggregation().Field(filter.Filter).Size(0x7FFFFFFF).
+		SubAggregation("filter", elastic.NewTermsAggregation().Field(filter.Filter).Size(maxAggregationSize).
 			SubAggregation("cost", elastic.NewSumAggregation().Field("unblendedCost")))
 	if filter.Type == "time" {
 		aggregation = elastic.NewReverseNestedAggregation().
@@ -137,8 +137,8 @@ func makeElasticSearchRequestForTagsValues(ctx context.Context, params tagsValue
 	}
 	search := client.Search().Index(index).Size(0).Query(query)
 	search.Aggregation("data", elastic.NewNestedAggregation().Path("tags").
-		SubAggregation("keys", elastic.NewTermsAggregation().Field("tags.key").
-			SubAggregation("tags", elastic.NewTermsAggregation().Field("tags.tag").
+		SubAggregation("keys", elastic.NewTermsAggregation().Field("tags.key").Size(maxAggregationSize).
+			SubAggregation("tags", elastic.NewTermsAggregation().Field("tags.tag").Size(maxAggregationSize).
 				SubAggregation("rev", aggregation))))
 	res, err := search.Do(ctx)
 	if err != nil {


### PR DESCRIPTION
I add the element `Size` in tags aggregations to be able to have more than 10 keys/values.