### PR TITLE
Updated plugins to work with subaccounts

### DIFF
--- a/db/migration/0025_plugins_view_subaccounts.sql
+++ b/db/migration/0025_plugins_view_subaccounts.sql
@@ -1,0 +1,17 @@
+--   Copyright 2018 MSolution.IO
+--
+--   Licensed under the Apache License, Version 2.0 (the "License");
+--   you may not use this file except in compliance with the License.
+--   You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--   Unless required by applicable law or agreed to in writing, software
+--   distributed under the License is distributed on an "AS IS" BASIS,
+--   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--   See the License for the specific language governing permissions and
+--   limitations under the License.
+
+CREATE OR REPLACE VIEW aws_account_plugins_due_update AS
+	SELECT * FROM aws_account WHERE next_update_plugins <= NOW()
+;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -578,3 +578,21 @@ CREATE VIEW aws_account_status AS
 	)
 	SELECT aws_bill_repository_id, created, completed, error FROM jobs WHERE rn = 1
 ;
+
+--   Copyright 2018 MSolution.IO
+--
+--   Licensed under the Apache License, Version 2.0 (the "License");
+--   you may not use this file except in compliance with the License.
+--   You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--   Unless required by applicable law or agreed to in writing, software
+--   distributed under the License is distributed on an "AS IS" BASIS,
+--   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--   See the License for the specific language governing permissions and
+--   limitations under the License.
+
+CREATE OR REPLACE VIEW aws_account_plugins_due_update AS
+	SELECT * FROM aws_account WHERE next_update_plugins <= NOW()
+;

--- a/plugins/README.adoc
+++ b/plugins/README.adoc
@@ -25,12 +25,12 @@ There are a few rules a plugin must respect in order to work:
 ----
 func init() {
 	core.AccountPlugin{
-    Name:             "My unique plugin name",
-    Description:      "My plugin description",
-    Category:         "My plugin category (example: EC2)",
-    Label:            "The label used to display the number of checks (will be displayed with the following format on the front end: <passed> <label>(s))"
-    Func:             myHandlerFunction,
-    PayerAccountOnly: false, // Set to true if billings are required
+    Name:               "My unique plugin name",
+    Description:        "My plugin description",
+    Category:           "My plugin category (example: EC2)",
+    Label:              "The label used to display the number of checks (will be displayed with the following format on the front end: <passed> <label>(s))"
+    Func:               myHandlerFunction,
+    BillingDataOnly:    false, // Set to true if the plugin does not require a role to access the AWS API
 	}.Register()
 }
 ----

--- a/plugins/account/core/core.go
+++ b/plugins/account/core/core.go
@@ -27,12 +27,12 @@ import (
 // AccountPlugin is the struct that defines the variables and functions a plugin
 // needs to use
 type AccountPlugin struct {
-	Name             string
-	Description      string
-	Category         string
-	Label            string
-	Func             PluginFunc
-	PayerAccountOnly bool
+	Name            string
+	Description     string
+	Category        string
+	Label           string
+	Func            PluginFunc
+	BillingDataOnly bool
 }
 
 // PluginParams is the struct that is passed as a parameter for each plugin

--- a/plugins/account/s3Traffic/es_request_constructor.go
+++ b/plugins/account/s3Traffic/es_request_constructor.go
@@ -34,10 +34,12 @@ func createQueryTimeRange(durationBegin time.Time, durationEnd time.Time) *elast
 // Parameters:
 // - durationBegin and durationEnd: parameters to define the time interval
 // - client: preconfigured elasticsearch client
+// - account: the aws account id to use for filtering
 // - index: the index on which the query should be executed
 // It returns an elastic.SearchService that can be used to execute the search
-func GetS3StorageUsage(durationBegin time.Time, durationEnd time.Time, client *elastic.Client, index string) *elastic.SearchService {
+func GetS3StorageUsage(durationBegin time.Time, durationEnd time.Time, client *elastic.Client, account, index string) *elastic.SearchService {
 	query := elastic.NewBoolQuery()
+	query = query.Filter(elastic.NewTermQuery("usageAccountId", account))
 	query = query.Filter(createQueryTimeRange(durationBegin, durationEnd))
 	query = query.Filter(elastic.NewTermQuery("productCode", "AmazonS3"))
 	// We only want to get standard storage
@@ -53,10 +55,12 @@ func GetS3StorageUsage(durationBegin time.Time, durationEnd time.Time, client *e
 // Parameters:
 // - durationBegin and durationEnd: parameters to define the time interval
 // - client: preconfigured elasticsearch client
+// - account: the aws account id to use for filtering
 // - index: the index on which the query should be executed
 // It returns an elastic.SearchService that can be used to execute the search
-func GetS3BandwidthUsage(durationBegin time.Time, durationEnd time.Time, client *elastic.Client, index string) *elastic.SearchService {
+func GetS3BandwidthUsage(durationBegin time.Time, durationEnd time.Time, client *elastic.Client, account, index string) *elastic.SearchService {
 	query := elastic.NewBoolQuery()
+	query = query.Filter(elastic.NewTermQuery("usageAccountId", account))
 	query = query.Filter(createQueryTimeRange(durationBegin, durationEnd))
 	query = query.Filter(elastic.NewTermQuery("productCode", "AmazonS3"))
 	query = query.Filter(elastic.NewWildcardQuery("usageType", "*-Bytes"))

--- a/plugins/account/s3Traffic/s3Traffic.go
+++ b/plugins/account/s3Traffic/s3Traffic.go
@@ -27,12 +27,12 @@ import (
 func init() {
 	// Register the plugin
 	core.AccountPlugin{
-		Name:             "S3 traffic",
-		Description:      "Get the list of s3 buckets with no traffic over the last month",
-		Category:         utils.PluginsCategories["S3"],
-		Label:            "bucket(s) with traffic",
-		Func:             handlerS3Traffic,
-		PayerAccountOnly: true,
+		Name:            "S3 traffic",
+		Description:     "Get the list of s3 buckets with no traffic over the last month",
+		Category:        utils.PluginsCategories["S3"],
+		Label:           "bucket(s) with traffic",
+		Func:            handlerS3Traffic,
+		BillingDataOnly: true,
 	}.Register()
 }
 
@@ -66,7 +66,7 @@ func processS3Traffic(pluginParams core.PluginParams, pluginRes *core.PluginResu
 	endDate := time.Now().UTC()
 	esIndex := es.IndexNameForUserId(pluginParams.User.Id, ts3.IndexPrefixLineItem)
 
-	searchService := GetS3StorageUsage(beginDate, endDate, pluginParams.ESClient, esIndex)
+	searchService := GetS3StorageUsage(beginDate, endDate, pluginParams.ESClient, pluginParams.AccountId, esIndex)
 	res, err := searchService.Do(pluginParams.Context)
 	if err != nil {
 		pluginRes.Status = "red"
@@ -80,7 +80,7 @@ func processS3Traffic(pluginParams core.PluginParams, pluginRes *core.PluginResu
 		return
 	}
 
-	searchService = GetS3BandwidthUsage(beginDate, endDate, pluginParams.ESClient, esIndex)
+	searchService = GetS3BandwidthUsage(beginDate, endDate, pluginParams.ESClient, pluginParams.AccountId, esIndex)
 	res, err = searchService.Do(pluginParams.Context)
 	if err != nil {
 		pluginRes.Status = "red"

--- a/server/taskProcessAccountPlugins.go
+++ b/server/taskProcessAccountPlugins.go
@@ -86,7 +86,7 @@ func preparePluginsProcessingForAccount(ctx context.Context, aaId int) (err erro
 func runPluginsForAccount(ctx context.Context, user users.User, aa aws.AwsAccount) {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	for _, plugin := range core.RegisteredAccountPlugins {
-		if plugin.PayerAccountOnly == true && aa.Payer == false {
+		if plugin.BillingDataOnly == false && aa.RoleArn == "" {
 			continue
 		}
 		accountId := aa.AwsIdentity
@@ -97,19 +97,23 @@ func runPluginsForAccount(ctx context.Context, user users.User, aa aws.AwsAccoun
 			Category:   plugin.Category,
 			Label:      plugin.Label,
 		}
-		creds, err := aws.GetTemporaryCredentials(aa, fmt.Sprintf("trackit-%s-plugin", plugin.Name))
-		if err != nil {
-			logger.Error("Error when getting temporary credentials", err.Error())
-			pluginResultES.Error = fmt.Sprintf("Error when getting temporary credentials: %s", err.Error())
-		} else {
-			params := core.PluginParams{
-				Context:            ctx,
-				User:               user,
-				AwsAccount:         aa,
-				AccountId:          accountId,
-				AccountCredentials: creds,
-				ESClient:           es.Client,
+		params := core.PluginParams{
+			Context:    ctx,
+			User:       user,
+			AwsAccount: aa,
+			AccountId:  accountId,
+			ESClient:   es.Client,
+		}
+		if plugin.BillingDataOnly == false {
+			creds, err := aws.GetTemporaryCredentials(aa, fmt.Sprintf("trackit-%s-plugin", plugin.Name))
+			if err != nil {
+				logger.Error("Error when getting temporary credentials", err.Error())
+				pluginResultES.Error = fmt.Sprintf("Error when getting temporary credentials: %s", err.Error())
+			} else {
+				params.AccountCredentials = creds
 			}
+		}
+		if pluginResultES.Error == "" {
 			res := plugin.Func(params)
 			pluginResultES.Result = res.Result
 			pluginResultES.Status = res.Status


### PR DESCRIPTION
This PR updates the plugins to work with subaccounts.
It replace the PayerAccountOnly configuration parameter by BillingDataOnly so that subaccounts are also processed. When BillingDataOnly is set to false, the plugin is only executed for accounts with a role configured