### PR TITLE
Add RDS Tags & manage unused with -1

### DIFF
--- a/aws/usageReports/rds/dailyReport.go
+++ b/aws/usageReports/rds/dailyReport.go
@@ -46,6 +46,7 @@ func fetchDailyInstancesList(ctx context.Context, creds *credentials.Credentials
 		return err
 	}
 	for _, DBInstance := range instances.DBInstances {
+		tags := getInstanceTags(ctx, DBInstance, svc)
 		stats := getInstanceStats(ctx, DBInstance, sess, start, end)
 		InstanceChan <- Instance{
 			InstanceBase: InstanceBase{
@@ -56,6 +57,7 @@ func fetchDailyInstancesList(ctx context.Context, creds *credentials.Credentials
 				AllocatedStorage:     aws.Int64Value(DBInstance.AllocatedStorage),
 				MultiAZ:              aws.BoolValue(DBInstance.MultiAZ),
 			},
+			Tags:  tags,
 			Costs: make(map[string]float64, 0),
 			Stats: stats,
 		}

--- a/aws/usageReports/rds/mappings.go
+++ b/aws/usageReports/rds/mappings.go
@@ -42,7 +42,7 @@ func init() {
 const TemplateRDSReport = `
 {
 	"template": "*-rds-reports",
-	"version": 4,
+	"version": 5,
 	"mappings": {
 		"rds-report": {
 			"properties": {
@@ -75,6 +75,17 @@ const TemplateRDSReport = `
 						},
 						"multiAZ": {
 							"type": "boolean"
+						},
+						"tags": {
+							"type": "nested",
+							"properties": {
+								"key": {
+									"type": "keyword"
+								},
+								"value": {
+									"type": "keyword"
+								}
+							}
 						},
 						"costs": {
 							"type": "object"

--- a/aws/usageReports/rds/metricsStats.go
+++ b/aws/usageReports/rds/metricsStats.go
@@ -30,20 +30,20 @@ import (
 // getInstanceTags returns an array of tags associated to the RDS instance given as parameter
 func getInstanceTags(ctx context.Context, instance *rds.DBInstance, svc *rds.RDS) []utils.Tag {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
-	tags := make([]utils.Tag, 0)
 	desc := rds.ListTagsForResourceInput{
 		ResourceName: instance.DBInstanceArn,
 	}
 	res, err := svc.ListTagsForResource(&desc)
 	if err != nil {
 		logger.Error("Failed to get RDS tags", err.Error())
-		return tags
+		return []utils.Tag{}
 	}
-	for _, tag := range res.TagList {
-		tags = append(tags, utils.Tag{
+	tags := make([]utils.Tag, len(res.TagList))
+	for i, tag := range res.TagList {
+		tags[i] = utils.Tag{
 			Key:   aws.StringValue(tag.Key),
 			Value: aws.StringValue(tag.Value),
-		})
+		}
 	}
 	return tags
 }

--- a/aws/usageReports/rds/monthlyReport.go
+++ b/aws/usageReports/rds/monthlyReport.go
@@ -45,6 +45,7 @@ func fetchMonthlyInstancesList(ctx context.Context, creds *credentials.Credentia
 		return err
 	}
 	for _, DBInstance := range instances.DBInstances {
+		tags := getInstanceTags(ctx, DBInstance, svc)
 		stats := getInstanceStats(ctx, DBInstance, sess, startDate, endDate)
 		costs := make(map[string]float64, 0)
 		costs["instance"] = inst.Cost
@@ -57,6 +58,7 @@ func fetchMonthlyInstancesList(ctx context.Context, creds *credentials.Credentia
 				AllocatedStorage:     aws.Int64Value(DBInstance.AllocatedStorage),
 				MultiAZ:              aws.BoolValue(DBInstance.MultiAZ),
 			},
+			Tags:  tags,
 			Costs: costs,
 			Stats: stats,
 		}

--- a/aws/usageReports/rds/utils.go
+++ b/aws/usageReports/rds/utils.go
@@ -51,6 +51,7 @@ type (
 	// Instance contains the information of an RDS instance
 	Instance struct {
 		InstanceBase
+		Tags  []utils.Tag        `json:"tags"`
 		Costs map[string]float64 `json:"costs"`
 		Stats Stats              `json:"stats"`
 	}

--- a/reports/rds.go
+++ b/reports/rds.go
@@ -22,8 +22,7 @@ import (
 
 	"github.com/trackit/trackit-server/aws"
 	"github.com/trackit/trackit-server/aws/usageReports/history"
-	"github.com/trackit/trackit-server/aws/usageReports/rds"
-	usageReports "github.com/trackit/trackit-server/usageReports/rds"
+	"github.com/trackit/trackit-server/usageReports/rds"
 	"github.com/trackit/trackit-server/users"
 )
 
@@ -83,7 +82,7 @@ func getRdsUsageReport(ctx context.Context, aa aws.AwsAccount, tx *sql.Tx) (data
 		return
 	}
 
-	parameters := usageReports.RdsQueryParams{
+	parameters := rds.RdsQueryParams{
 		AccountList: []string{identity},
 		Date: date,
 	}
@@ -91,7 +90,7 @@ func getRdsUsageReport(ctx context.Context, aa aws.AwsAccount, tx *sql.Tx) (data
 	logger.Debug("Getting RDS Usage Report for account", map[string]interface{}{
 		"account": aa,
 	})
-	_, reports, err := usageReports.GetRdsData(ctx, parameters, user, tx)
+	_, reports, err := rds.GetRdsData(ctx, parameters, user, tx)
 	if err != nil {
 		return
 	}

--- a/usageReports/ec2/prepare_response.go
+++ b/usageReports/ec2/prepare_response.go
@@ -226,7 +226,9 @@ func prepareResponseEc2Monthly(ctx context.Context, resEc2 *elastic.SearchResult
 func isInstanceUnused(instance Instance) bool {
 	average := instance.Stats.Cpu.Average
 	peak := instance.Stats.Cpu.Peak
-	if peak >= 60.0 {
+	if average == -1 || peak == -1 {
+		return false
+	} else if peak >= 60.0 {
 		return false
 	} else if average >= 10.0 {
 		return false

--- a/usageReports/es/prepare_response.go
+++ b/usageReports/es/prepare_response.go
@@ -187,7 +187,9 @@ func prepareResponseEsMonthly(ctx context.Context, resEc2 *elastic.SearchResult)
 func isDomainUnused(domain Domain) bool {
 	average := domain.Stats.Cpu.Average
 	peak := domain.Stats.Cpu.Peak
-	if peak >= 60.0 {
+	if average == -1 || peak == -1 {
+		return false
+	} else if peak >= 60.0 {
 		return false
 	} else if average >= 10 {
 		return false

--- a/usageReports/rds/get_rds_data.go
+++ b/usageReports/rds/get_rds_data.go
@@ -68,7 +68,7 @@ func makeElasticSearchRequest(ctx context.Context, parsedParams RdsQueryParams,
 }
 
 // GetRdsMonthlyInstances does an elastic request and returns an array of instances monthly report based on query params
-func GetRdsMonthlyInstances(ctx context.Context, params RdsQueryParams) (int, []rds.InstanceReport, error) {
+func GetRdsMonthlyInstances(ctx context.Context, params RdsQueryParams) (int, []InstanceReport, error) {
 	res, returnCode, err := makeElasticSearchRequest(ctx, params, getElasticSearchRdsMonthlyParams)
 	if err != nil {
 		return returnCode, nil, err
@@ -81,7 +81,7 @@ func GetRdsMonthlyInstances(ctx context.Context, params RdsQueryParams) (int, []
 }
 
 // GetRdsDailyInstances does an elastic request and returns an array of instances daily report based on query params
-func GetRdsDailyInstances(ctx context.Context, params RdsQueryParams, user users.User, tx *sql.Tx) (int, []rds.InstanceReport, error) {
+func GetRdsDailyInstances(ctx context.Context, params RdsQueryParams, user users.User, tx *sql.Tx) (int, []InstanceReport, error) {
 	res, returnCode, err := makeElasticSearchRequest(ctx, params, getElasticSearchRdsDailyParams)
 	if err != nil {
 		return returnCode, nil, err
@@ -101,7 +101,7 @@ func GetRdsDailyInstances(ctx context.Context, params RdsQueryParams, user users
 }
 
 // GetRdsData gets RDS monthly reports based on query params, if there isn't a monthly report, it calls getRdsDailyInstances
-func GetRdsData(ctx context.Context, parsedParams RdsQueryParams, user users.User, tx *sql.Tx) (int, []rds.InstanceReport, error) {
+func GetRdsData(ctx context.Context, parsedParams RdsQueryParams, user users.User, tx *sql.Tx) (int, []InstanceReport, error) {
 	accountsAndIndexes, returnCode, err := es.GetAccountsAndIndexes(parsedParams.AccountList, user, tx, rds.IndexPrefixRDSReport)
 	if err != nil {
 		return returnCode, nil, err
@@ -122,7 +122,7 @@ func GetRdsData(ctx context.Context, parsedParams RdsQueryParams, user users.Use
 }
 
 // GetRdsUnusedData gets RDS reports and parse them based on query params to have an array of unused instances
-func GetRdsUnusedData(ctx context.Context, params RdsUnusedQueryParams, user users.User, tx *sql.Tx) (int, []rds.InstanceReport, error) {
+func GetRdsUnusedData(ctx context.Context, params RdsUnusedQueryParams, user users.User, tx *sql.Tx) (int, []InstanceReport, error) {
 	returnCode, instances, err := GetRdsData(ctx, RdsQueryParams{params.AccountList, nil, params.Date}, user, tx)
 	if err != nil {
 		return returnCode, nil, err

--- a/usageReports/rds/prepare_response.go
+++ b/usageReports/rds/prepare_response.go
@@ -99,7 +99,7 @@ type (
 )
 
 func getRdsInstanceReportResponse(oldInstance rds.InstanceReport) InstanceReport {
-	tags := make(map[string]string, 0)
+	tags := make(map[string]string, len(oldInstance.Instance.Tags))
 	for _, tag := range oldInstance.Instance.Tags {
 		tags[tag.Key] = tag.Value
 	}


### PR DESCRIPTION
This PR adds tags to rds reports (don't need to reindex data).
It now manage when an instance don't have metrics (-1) to not return it on the `[resource]/unused` route.