### PR TITLE
[bugfix] Trim spaces when checking rolearn is empty

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"log"
 	"regexp"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/trackit/jsonlog"
@@ -218,7 +219,7 @@ func (a *AwsAccount) UpdateIdentityAwsAccount(ctx context.Context, tx *sql.Tx) e
 
 // GetAwsAccountIdentity returns the AWS identity of an AWS Account.
 func (a *AwsAccount) GetAwsAccountIdentity() (identity string, err error) {
-	if a.RoleArn == "" {
+	if strings.TrimSpace(a.RoleArn) == "" {
 		return a.AwsIdentity, nil
 	} else if reg, err := regexp.Compile("^arn:aws:iam::([0-9]{12}):.*$"); err != nil {
 		return "", err

--- a/db/migration/0031_trim_role_arn.sql
+++ b/db/migration/0031_trim_role_arn.sql
@@ -1,0 +1,17 @@
+--   Copyright 2018 MSolution.IO
+--
+--   Licensed under the Apache License, Version 2.0 (the "License");
+--   you may not use this file except in compliance with the License.
+--   You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--   Unless required by applicable law or agreed to in writing, software
+--   distributed under the License is distributed on an "AS IS" BASIS,
+--   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--   See the License for the specific language governing permissions and
+--   limitations under the License.
+
+CREATE OR REPLACE VIEW aws_account_due_update AS
+	SELECT * FROM aws_account WHERE next_update <= NOW() AND replace(role_arn, ' ','') != ""
+;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -685,3 +685,21 @@ ALTER TABLE aws_account ADD last_anomalies_update DATETIME NOT NULL DEFAULT "197
 --   limitations under the License.
 
 ALTER TABLE aws_account_update_job ADD elastiCacheError VARCHAR(255) NOT NULL DEFAULT "";
+
+--   Copyright 2018 MSolution.IO
+--
+--   Licensed under the Apache License, Version 2.0 (the "License");
+--   you may not use this file except in compliance with the License.
+--   You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--   Unless required by applicable law or agreed to in writing, software
+--   distributed under the License is distributed on an "AS IS" BASIS,
+--   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--   See the License for the specific language governing permissions and
+--   limitations under the License.
+
+CREATE OR REPLACE VIEW aws_account_due_update AS
+	SELECT * FROM aws_account WHERE next_update <= NOW() AND replace(role_arn, ' ','') != ""
+;

--- a/server/taskProcessAccountPlugins.go
+++ b/server/taskProcessAccountPlugins.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/trackit/jsonlog"
@@ -86,7 +87,7 @@ func preparePluginsProcessingForAccount(ctx context.Context, aaId int) (err erro
 func runPluginsForAccount(ctx context.Context, user users.User, aa aws.AwsAccount) {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	for _, plugin := range core.RegisteredAccountPlugins {
-		if plugin.BillingDataOnly == false && aa.RoleArn == "" {
+		if plugin.BillingDataOnly == false && strings.TrimSpace(aa.RoleArn) == "" {
 			continue
 		}
 		accountId := aa.AwsIdentity


### PR DESCRIPTION
This PR add trims when checking if a role arn is empty.
For some reason it seems some sub accounts have spaces instead of an empty string as the default role arn.

I was not able to reproduce the issue, the subaccounts are properly created with empty roles when testing locally but this issue happens on production and creates unexpected behaviors