### PR TITLE
Dump arguments when logging a route panic

### DIFF
--- a/db/decorator.go
+++ b/db/decorator.go
@@ -17,6 +17,7 @@ package db
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/trackit/jsonlog"
@@ -54,7 +55,10 @@ func (d RequestTransaction) getFunc(hf routes.HandlerFunc) routes.HandlerFunc {
 					transaction.Rollback()
 					status = http.StatusInternalServerError
 					output = errors.New("server suffered irrecoverable error")
-					logger.Error("Route handler panicked.", rec)
+					logger.Error("Route handler panicked.", map[string]interface{}{
+						"error":         rec,
+						"argumentsDump": fmt.Sprintf("%+v", a),
+					})
 				} else if _, ok := output.(error); ok {
 					transaction.Rollback()
 				} else {


### PR DESCRIPTION
This PR updates the route panic logging to dump the route arguments in the logs to help debugging