### PR TITLE
[TRAC-1106] EC2 coverage

### DIFF
--- a/aws/usageReports/ec2Coverage/mappings.go
+++ b/aws/usageReports/ec2Coverage/mappings.go
@@ -1,0 +1,98 @@
+//   Copyright 2018 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package ec2Coverage
+
+import (
+	"context"
+	"time"
+
+	"github.com/trackit/jsonlog"
+
+	"github.com/trackit/trackit-server/es"
+)
+
+const TypeEC2CoverageReport = "ec2-coverage-report"
+const IndexPrefixEC2CoverageReport = "ec2-coverage-reports"
+const TemplateNameEC2CoverageReport = "ec2-coverage-reports"
+
+// put the ElasticSearch index for *-ec2-coverage-reports indices at startup.
+func init() {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	res, err := es.Client.IndexPutTemplate(TemplateNameEC2CoverageReport).BodyString(TemplateEc2CoverageReport).Do(ctx)
+	if err != nil {
+		jsonlog.DefaultLogger.Error("Failed to put ES index EC2 Coverage Report.", err)
+	} else {
+		jsonlog.DefaultLogger.Info("Put ES index EC2 Coverage Report.", res)
+		ctxCancel()
+	}
+}
+
+const TemplateEc2CoverageReport = `
+{
+	"template": "*-ec2-coverage-reports",
+	"version": 1,
+	"mappings": {
+		"ec2-coverage-report": {
+			"properties": {
+				"account": {
+					"type": "keyword"
+				},
+				"reportDate": {
+					"type": "date"
+				},
+				"reportType": {
+					"type": "keyword"
+				},
+				"reservation": {
+					"properties": {
+						"type": {
+							"type": "keyword"
+						},
+						"platform": {
+							"type": "keyword"
+						},
+						"tenancy": {
+							"type": "keyword"
+						},
+						"region": {
+							"type": "keyword"
+						},
+						"averageCoverage": {
+							"type": "double"
+						},
+						"coveredHours": {
+							"type": "double"
+						},
+						"onDemandHours": {
+							"type": "double"
+						},
+						"totalRunningHours": {
+							"type": "double"
+						},
+						"instancesNames": {
+							"type": "keyword"
+						}
+					}
+				}
+			},
+			"_all": {
+				"enabled": false
+			},
+			"numeric_detection": false,
+			"date_detection": false
+		}
+	}
+}
+`

--- a/aws/usageReports/ec2Coverage/monthlyReport.go
+++ b/aws/usageReports/ec2Coverage/monthlyReport.go
@@ -1,0 +1,152 @@
+//   Copyright 2018 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package ec2Coverage
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/costexplorer"
+	"github.com/trackit/jsonlog"
+
+	taws "github.com/trackit/trackit-server/aws"
+	"github.com/trackit/trackit-server/aws/usageReports"
+	"github.com/trackit/trackit-server/db"
+	"github.com/trackit/trackit-server/usageReports/ec2"
+	"github.com/trackit/trackit-server/users"
+)
+
+// geEc2CoverageReport get EC2 coverage data from the AWS Cost Explorer
+func getEc2CoverageReport(creds *credentials.Credentials, start time.Time) (*costexplorer.GetReservationCoverageOutput, error) {
+	end := time.Date(start.Year(), start.Month()+1, 1, 0, 0, 0, 0, start.Location())
+	sess := session.Must(session.NewSession(&aws.Config{
+		Credentials: creds,
+		Region:      aws.String(""),
+	}))
+	svc := costexplorer.New(sess)
+	input := costexplorer.GetReservationCoverageInput{
+		TimePeriod: &costexplorer.DateInterval{
+			Start: aws.String(start.Format("2006-01-02")),
+			End:   aws.String(end.Format("2006-01-02")),
+		},
+		GroupBy: []*costexplorer.GroupDefinition{
+			{
+				Key:  aws.String("INSTANCE_TYPE"),
+				Type: aws.String("DIMENSION"),
+			}, {
+				Key:  aws.String("PLATFORM"),
+				Type: aws.String("DIMENSION"),
+			}, {
+				Key:  aws.String("TENANCY"),
+				Type: aws.String("DIMENSION"),
+			}, {
+				Key:  aws.String("REGION"),
+				Type: aws.String("DIMENSION"),
+			},
+		},
+	}
+	reservations, err := svc.GetReservationCoverage(&input)
+	if err != nil {
+		return nil, err
+	} else {
+		return reservations, nil
+	}
+}
+
+// getInstancesNames return an array of the names of the instances which are linked to a reservation
+func getInstancesNames(report Reservation, instances []ec2.InstanceReport) []string {
+	names := make([]string, 0)
+	for _, instance := range instances {
+		if name, ok := instance.Instance.Tags["Name"]; ok && instance.Instance.Type == report.Type &&
+			strings.Contains(instance.Instance.Region, report.Region) && instance.Instance.Purchasing == "on demand" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func generateEc2ReservationReport(ctx context.Context, aa taws.AwsAccount, start time.Time, instances []ec2.InstanceReport, reservations *costexplorer.GetReservationCoverageOutput) (bool, error) {
+	reports := make([]ReservationReport, 0)
+	for _, covByTime := range reservations.CoveragesByTime {
+		for _, group := range covByTime.Groups {
+			report := Reservation{
+				Type:     aws.StringValue(group.Attributes["instanceType"]),
+				Platform: aws.StringValue(group.Attributes["platform"]),
+				Tenancy:  aws.StringValue(group.Attributes["tenancy"]),
+				Region:   aws.StringValue(group.Attributes["region"]),
+			}
+			cov := group.Coverage.CoverageHours
+			if value, err := strconv.ParseFloat(aws.StringValue(cov.CoverageHoursPercentage), 64); err == nil {
+				report.AverageCoverage = value
+			}
+			if value, err := strconv.ParseFloat(aws.StringValue(cov.ReservedHours), 64); err == nil {
+				report.CoveredHours = value
+			}
+			if value, err := strconv.ParseFloat(aws.StringValue(cov.OnDemandHours), 64); err == nil {
+				report.OnDemandHours = value
+			}
+			if value, err := strconv.ParseFloat(aws.StringValue(cov.TotalRunningHours), 64); err == nil {
+				report.TotalRunningHours = value
+			}
+			report.InstancesNames = getInstancesNames(report, instances)
+			reports = append(reports, ReservationReport{
+				ReportBase: utils.ReportBase{
+					Account:    aa.AwsIdentity,
+					ReportType: "monthly",
+					ReportDate: start,
+				},
+				Reservation: report,
+			})
+		}
+	}
+	return importReportsToEs(ctx, aa, reports)
+}
+
+// PutEc2MonthlyCoverageReport puts a monthly report of EC2 reservation in ES
+func PutEc2MonthlyCoverageReport(ctx context.Context, aa taws.AwsAccount, start, end time.Time) (bool, error) {
+	logger := jsonlog.LoggerFromContextOrDefault(ctx)
+	logger.Info("Starting EC2 Coverage monthly report", map[string]interface{}{
+		"awsAccountId": aa.Id,
+		"startDate":    start.Format("2006-01-02T15:04:05Z"),
+		"endDate":      end.Format("2006-01-02T15:04:05Z"),
+	})
+	if already, err := utils.CheckMonthlyReportExists(ctx, start, aa, IndexPrefixEC2CoverageReport); err != nil {
+		return false, err
+	} else if already {
+		logger.Info("There is already an EC2 Coverage monthly report", nil)
+		return false, nil
+	} else if tx, err := db.Db.Begin(); err != nil {
+		logger.Error("Failed to begin Tx for DB", err.Error())
+		return false, err
+	} else if user, err := users.GetUserWithId(tx, aa.UserId); err != nil {
+		logger.Error("Failed to get User by Id", err.Error())
+		return false, err
+	} else if _, instances, err := ec2.GetEc2Data(ctx, ec2.Ec2QueryParams{[]string{aa.AwsIdentity}, nil, start}, user, tx); err != nil {
+		return false, err
+	} else if creds, err := taws.GetTemporaryCredentials(aa, "monitor-coverage"); err != nil {
+		logger.Error("Error when getting temporary credentials", err.Error())
+		return false, err
+	} else if reservations, err := getEc2CoverageReport(creds, start); err != nil {
+		logger.Error("Failed to get EC2 Coverage report from Cost Explorer", err.Error())
+		return false, err
+	} else {
+		return generateEc2ReservationReport(ctx, aa, start, instances, reservations)
+	}
+}

--- a/aws/usageReports/ec2Coverage/utils.go
+++ b/aws/usageReports/ec2Coverage/utils.go
@@ -1,0 +1,101 @@
+//   Copyright 2018 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package ec2Coverage
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/json"
+	"time"
+
+	"github.com/satori/go.uuid"
+	"github.com/trackit/jsonlog"
+
+	"github.com/trackit/trackit-server/aws"
+	"github.com/trackit/trackit-server/aws/usageReports"
+	"github.com/trackit/trackit-server/es"
+)
+
+type (
+	// ReservationReport is saved in ES to have all the information of an EC2 reservation
+	ReservationReport struct {
+		utils.ReportBase
+		Reservation Reservation `json:"reservation"`
+	}
+
+	// Reservation contains basics information of an EC2 reservation
+	Reservation struct {
+		Type              string   `json:"type"`
+		Platform          string   `json:"platform"`
+		Tenancy           string   `json:"tenancy"`
+		Region            string   `json:"region"`
+		AverageCoverage   float64  `json:"averageCoverage"`
+		CoveredHours      float64  `json:"coveredHours"`
+		OnDemandHours     float64  `json:"onDemandHours"`
+		TotalRunningHours float64  `json:"totalRunningHours"`
+		InstancesNames    []string `json:"instancesNames"`
+	}
+)
+
+// importReservationsToEs imports EC2 Coverage report in ElasticSearch.
+// It calls createIndexEs if the index doesn't exist.
+func importReportsToEs(ctx context.Context, aa aws.AwsAccount, reservations []ReservationReport) (bool, error) {
+	logger := jsonlog.LoggerFromContextOrDefault(ctx)
+	logger.Info("Updating EC2 Coverage report for AWS account.", map[string]interface{}{
+		"awsAccount": aa,
+	})
+	index := es.IndexNameForUserId(aa.UserId, IndexPrefixEC2CoverageReport)
+	bp, err := utils.GetBulkProcessor(ctx)
+	if err != nil {
+		logger.Error("Failed to get bulk processor.", err.Error())
+		return false, err
+	}
+	logger.Info("le report", reservations)
+	for _, reservation := range reservations {
+		id, err := generateId(reservation)
+		if err != nil {
+			logger.Error("Error when marshaling reservation var", err.Error())
+			return false, err
+		}
+		bp = utils.AddDocToBulkProcessor(bp, reservation, TypeEC2CoverageReport, index, id)
+	}
+	bp.Flush()
+	err = bp.Close()
+	if err != nil {
+		logger.Error("Fail to put EC2 Coverage report in ES", err.Error())
+		return false, err
+	}
+	logger.Info("EC2 Coverage report put in ES", nil)
+	return true, nil
+}
+
+func generateId(reservation ReservationReport) (string, error) {
+	ji, err := json.Marshal(struct {
+		Account    string    `json:"account"`
+		ReportDate time.Time `json:"reportDate"`
+		Id         string    `json:"reservationId"`
+	}{
+		reservation.Account,
+		reservation.ReportDate,
+		uuid.NewV1().String(),
+	})
+	if err != nil {
+		return "", err
+	}
+	hash := md5.Sum(ji)
+	hash64 := base64.URLEncoding.EncodeToString(hash[:])
+	return hash64, nil
+}

--- a/aws/usageReports/ec2Coverage/utils.go
+++ b/aws/usageReports/ec2Coverage/utils.go
@@ -50,7 +50,7 @@ type (
 	}
 )
 
-// importReservationsToEs imports EC2 Coverage report in ElasticSearch.
+// importReportsToEs imports EC2 Coverage report in ElasticSearch.
 // It calls createIndexEs if the index doesn't exist.
 func importReportsToEs(ctx context.Context, aa aws.AwsAccount, reservations []ReservationReport) (bool, error) {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
@@ -74,7 +74,7 @@ func importReportsToEs(ctx context.Context, aa aws.AwsAccount, reservations []Re
 	bp.Flush()
 	err = bp.Close()
 	if err != nil {
-		logger.Error("Fail to put EC2 Coverage report in ES", err.Error())
+		logger.Error("Failed to put EC2 Coverage report in ES", err.Error())
 		return false, err
 	}
 	logger.Info("EC2 Coverage report put in ES", nil)

--- a/aws/usageReports/ec2Coverage/utils.go
+++ b/aws/usageReports/ec2Coverage/utils.go
@@ -63,7 +63,6 @@ func importReportsToEs(ctx context.Context, aa aws.AwsAccount, reservations []Re
 		logger.Error("Failed to get bulk processor.", err.Error())
 		return false, err
 	}
-	logger.Info("le report", reservations)
 	for _, reservation := range reservations {
 		id, err := generateId(reservation)
 		if err != nil {

--- a/aws/usageReports/history/history.go
+++ b/aws/usageReports/history/history.go
@@ -28,6 +28,7 @@ import (
 	"github.com/trackit/trackit-server/aws"
 	"github.com/trackit/trackit-server/aws/usageReports"
 	"github.com/trackit/trackit-server/aws/usageReports/ec2"
+	"github.com/trackit/trackit-server/aws/usageReports/ec2Coverage"
 	"github.com/trackit/trackit-server/aws/usageReports/elasticache"
 	tes "github.com/trackit/trackit-server/aws/usageReports/es"
 	"github.com/trackit/trackit-server/aws/usageReports/rds"
@@ -178,8 +179,9 @@ func getInstancesInfo(ctx context.Context, aa aws.AwsAccount, startDate time.Tim
 	if elastiCacheErr == nil {
 		elastiCacheCreated, elastiCacheErr = elasticache.PutElastiCacheMonthlyReport(ctx, elastiCacheCost, aa, startDate, endDate)
 	}
-	reportsCreated := (ec2Created || rdsCreated || esCreated || elastiCacheCreated)
-	return reportsCreated, concatErrors([]error{ec2Err, cloudWatchErr, rdsErr, esErr, elastiCacheErr})
+	ec2CoverageCreated, ec2CoverageErr := ec2Coverage.PutEc2MonthlyCoverageReport(ctx, aa, startDate, endDate)
+	reportsCreated := (ec2Created || rdsCreated || esCreated || elastiCacheCreated || ec2CoverageCreated)
+	return reportsCreated, concatErrors([]error{ec2Err, cloudWatchErr, rdsErr, esErr, elastiCacheErr, ec2CoverageErr})
 }
 
 // CheckBillingDataCompleted checks if billing data in ES are complete.

--- a/policies/all_policies.json
+++ b/policies/all_policies.json
@@ -36,7 +36,8 @@
                 "ec2:DescribeAddresses",
                 "organizations:ListAccounts",
                 "lambda:ListFunctions",
-                "lambda:ListTags"
+                "lambda:ListTags",
+                "ce:GetReservationCoverage"
             ],
             "Resource": "*"
         }

--- a/policies/tool_policies/monitor_ressources.json
+++ b/policies/tool_policies/monitor_ressources.json
@@ -21,7 +21,8 @@
         "ec2:DescribeVolumes",
         "ec2:DescribeAddresses",
         "lambda:ListFunctions",
-        "lambda:ListTags"
+        "lambda:ListTags",
+        "ce:GetReservationCoverage"
       ],
       "Effect": "Allow",
       "Resource": "*"

--- a/server/server.go
+++ b/server/server.go
@@ -39,6 +39,7 @@ import (
 	"github.com/trackit/trackit-server/routes"
 	_ "github.com/trackit/trackit-server/s3/costs"
 	_ "github.com/trackit/trackit-server/usageReports/ec2"
+	_ "github.com/trackit/trackit-server/usageReports/ec2Coverage"
 	_ "github.com/trackit/trackit-server/usageReports/elasticache"
 	_ "github.com/trackit/trackit-server/usageReports/es"
 	_ "github.com/trackit/trackit-server/usageReports/lambda"

--- a/server/taskProcessAccount.go
+++ b/server/taskProcessAccount.go
@@ -30,8 +30,8 @@ import (
 	"github.com/trackit/trackit-server/aws/usageReports/es"
 	"github.com/trackit/trackit-server/aws/usageReports/history"
 	"github.com/trackit/trackit-server/aws/usageReports/lambda"
-	"github.com/trackit/trackit-server/aws/usageReports/rds"
 	"github.com/trackit/trackit-server/aws/usageReports/reservedInstances"
+	"github.com/trackit/trackit-server/aws/usageReports/rds"
 	"github.com/trackit/trackit-server/db"
 )
 
@@ -211,7 +211,7 @@ func processAccountLambda(ctx context.Context, aa aws.AwsAccount) error {
 	return err
 }
 
-// processAccountHistory processes EC2, RDS, ES, ElastiCache and Lambda data with billing data for an AwsAccount
+// processAccountHistory processes EC2, RDS, ES, ElastiCache, Lambda and EC2 Coverage data with billing data for an AwsAccount
 func processAccountHistory(ctx context.Context, aa aws.AwsAccount) (bool, error) {
 	status, err := history.FetchHistoryInfos(ctx, aa)
 	if err != nil && err != history.ErrBillingDataIncomplete {

--- a/usageReports/ec2Coverage/ec2_coverage_route.go
+++ b/usageReports/ec2Coverage/ec2_coverage_route.go
@@ -1,0 +1,75 @@
+//   Copyright 2018 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package ec2Coverage
+
+import (
+	"database/sql"
+	"net/http"
+	"time"
+
+	"github.com/trackit/trackit-server/db"
+	"github.com/trackit/trackit-server/routes"
+	"github.com/trackit/trackit-server/users"
+)
+
+type (
+	// Ec2CoverageQueryParams will store the parsed query params
+	Ec2CoverageQueryParams struct {
+		AccountList []string
+		IndexList   []string
+		Date        time.Time
+	}
+)
+
+var (
+	// ec2CoverageQueryArgs allows to get required queryArgs params
+	ec2CoverageQueryArgs = []routes.QueryArg{
+		routes.AwsAccountsOptionalQueryArg,
+		routes.DateQueryArg,
+	}
+)
+
+func init() {
+	routes.MethodMuxer{
+		http.MethodGet: routes.H(getEc2CoverageReservations).With(
+			db.RequestTransaction{Db: db.Db},
+			users.RequireAuthenticatedUser{users.ViewerAsParent},
+			routes.QueryArgs(ec2CoverageQueryArgs),
+			routes.Documentation{
+				Summary:     "get the list of EC2 Coverage reports",
+				Description: "Responds with the list of EC2 Coverage reports based on the queryparams passed to it",
+			},
+		),
+	}.H().Register("/ec2/coverage")
+}
+
+// getEc2CoverageReservations returns the list of EC2 Coverage reports based on the query params, in JSON format.
+func getEc2CoverageReservations(request *http.Request, a routes.Arguments) (int, interface{}) {
+	user := a[users.AuthenticatedUser].(users.User)
+	tx := a[db.Transaction].(*sql.Tx)
+	parsedParams := Ec2CoverageQueryParams{
+		AccountList: []string{},
+		Date:        a[routes.DateQueryArg].(time.Time),
+	}
+	if a[routes.AwsAccountsOptionalQueryArg] != nil {
+		parsedParams.AccountList = a[routes.AwsAccountsOptionalQueryArg].([]string)
+	}
+	returnCode, report, err := GetEc2CoverageData(request.Context(), parsedParams, user, tx)
+	if err != nil {
+		return returnCode, err
+	} else {
+		return returnCode, report
+	}
+}

--- a/usageReports/ec2Coverage/es_request_constructor.go
+++ b/usageReports/ec2Coverage/es_request_constructor.go
@@ -1,0 +1,54 @@
+//   Copyright 2018 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package ec2Coverage
+
+import (
+	"gopkg.in/olivere/elastic.v5"
+)
+
+const maxAggregationSize = 0x7FFFFFFF
+
+// createQueryAccountFilterEc2Coverage creates and return a new *elastic.TermsQuery on the accountList array
+func createQueryAccountFilterEc2Coverage(accountList []string) *elastic.TermsQuery {
+	accountListFormatted := make([]interface{}, len(accountList))
+	for i, v := range accountList {
+		accountListFormatted[i] = v
+	}
+	return elastic.NewTermsQuery("account", accountListFormatted...)
+}
+
+// getElasticSearchEc2CoverageMonthlyParams is used to construct an ElasticSearch *elastic.SearchService used to perform a request on ES
+// It takes as parameters :
+// 	- params Ec2CoverageQueryParams : contains the list of accounts and the date
+//	- client *elastic.Client : an reservation of *elastic.Client that represent an Elastic Search client.
+//	It needs to be fully configured and ready to execute a client.Search()
+//	- index string : The Elastic Search index on which to execute the query. In this context the default value
+//	should be "ec2Coverage-reports"
+// This function excepts arguments passed to it to be sanitize. If they are not, the following cases will make
+// it crash :
+//	- If the client is nil or malconfigured, it will crash
+//	- If the index is not an index present in the ES, it will crash
+func getElasticSearchEc2CoverageMonthlyParams(params Ec2CoverageQueryParams, client *elastic.Client, index string) *elastic.SearchService {
+	query := elastic.NewBoolQuery()
+	if len(params.AccountList) > 0 {
+		query = query.Filter(createQueryAccountFilterEc2Coverage(params.AccountList))
+	}
+	query = query.Filter(elastic.NewTermQuery("reportType", "monthly"))
+	query = query.Filter(elastic.NewTermQuery("reportDate", params.Date))
+	search := client.Search().Index(index).Size(0).Query(query)
+	search.Aggregation("accounts", elastic.NewTermsAggregation().Field("account").
+		SubAggregation("reservations", elastic.NewTopHitsAggregation().Sort("reportDate", false).Size(maxAggregationSize)))
+	return search
+}

--- a/usageReports/ec2Coverage/get_ec2_coverage_data.go
+++ b/usageReports/ec2Coverage/get_ec2_coverage_data.go
@@ -1,0 +1,99 @@
+//   Copyright 2018 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package ec2Coverage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/trackit/jsonlog"
+	"gopkg.in/olivere/elastic.v5"
+
+	"github.com/trackit/trackit-server/aws/usageReports/ec2Coverage"
+	terrors "github.com/trackit/trackit-server/errors"
+	"github.com/trackit/trackit-server/es"
+	"github.com/trackit/trackit-server/users"
+)
+
+// makeElasticSearchRequest prepares and run an ES request
+// based on the ec2CoverageQueryParams and search params
+// It will return the data, an http status code (as int) and an error.
+// Because an error can be generated, but is not critical and is not needed to be known by
+// the user (e.g if the index does not exists because it was not yet indexed ) the error will
+// be returned, but instead of having a 500 status code, it will return the provided status code
+// with empty data
+func makeElasticSearchRequest(ctx context.Context, parsedParams Ec2CoverageQueryParams) (*elastic.SearchResult, int, error) {
+	l := jsonlog.LoggerFromContextOrDefault(ctx)
+	index := strings.Join(parsedParams.IndexList, ",")
+	searchService := getElasticSearchEc2CoverageMonthlyParams(
+		parsedParams,
+		es.Client,
+		index,
+	)
+	res, err := searchService.Do(ctx)
+	if err != nil {
+		if elastic.IsNotFound(err) {
+			l.Warning("Query execution failed, ES index does not exists", map[string]interface{}{
+				"index": index,
+				"error": err.Error(),
+			})
+			return nil, http.StatusOK, terrors.GetErrorMessage(ctx, err)
+		} else if cast, ok := err.(*elastic.Error); ok && cast.Details.Type == "search_phase_execution_exception" {
+			l.Error("Error while getting data from ES", map[string]interface{}{
+				"type":  fmt.Sprintf("%T", err),
+				"error": err,
+			})
+		} else {
+			l.Error("Query execution failed", map[string]interface{}{"error": err.Error()})
+		}
+		return nil, http.StatusInternalServerError, terrors.GetErrorMessage(ctx, err)
+	}
+	return res, http.StatusOK, nil
+}
+
+// GetEc2CoverageMonthlyReservations does an elastic request and returns an array of reservations monthly report based on query params
+func GetEc2CoverageMonthlyReservations(ctx context.Context, params Ec2CoverageQueryParams) (int, []ReservationReport, error) {
+	res, returnCode, err := makeElasticSearchRequest(ctx, params)
+	if err != nil {
+		return returnCode, nil, err
+	} else if res == nil {
+		return http.StatusInternalServerError, nil, errors.New("Error while getting data. Please check again in few hours.")
+	}
+	reservations, err := prepareResponseEc2CoverageMonthly(ctx, res)
+	if err != nil {
+		return http.StatusInternalServerError, nil, err
+	}
+	return http.StatusOK, reservations, nil
+}
+
+// GetEc2CoverageData gets EC2 Coverage monthly reports based on query params
+func GetEc2CoverageData(ctx context.Context, parsedParams Ec2CoverageQueryParams, user users.User, tx *sql.Tx) (int, []ReservationReport, error) {
+	accountsAndIndexes, returnCode, err := es.GetAccountsAndIndexes(parsedParams.AccountList, user, tx, ec2Coverage.IndexPrefixEC2CoverageReport)
+	if err != nil {
+		return returnCode, nil, err
+	}
+	parsedParams.AccountList = accountsAndIndexes.Accounts
+	parsedParams.IndexList = accountsAndIndexes.Indexes
+	returnCode, monthlyReservations, err := GetEc2CoverageMonthlyReservations(ctx, parsedParams)
+	if err != nil {
+		return returnCode, nil, err
+	} else {
+		return returnCode, monthlyReservations, nil
+	}
+}

--- a/usageReports/ec2Coverage/prepare_response.go
+++ b/usageReports/ec2Coverage/prepare_response.go
@@ -1,0 +1,71 @@
+//   Copyright 2018 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package ec2Coverage
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/trackit/jsonlog"
+	"gopkg.in/olivere/elastic.v5"
+
+	"github.com/trackit/trackit-server/aws/usageReports"
+	"github.com/trackit/trackit-server/aws/usageReports/ec2Coverage"
+	"github.com/trackit/trackit-server/errors"
+)
+
+type (
+	// Structure that allow to parse ES response for EC2 Coverage Monthly report
+	ResponseEc2CoverageMonthly struct {
+		Accounts struct {
+			Buckets []struct {
+				Reservations struct {
+					Hits struct {
+						Hits []struct {
+							Reservation ec2Coverage.ReservationReport `json:"_source"`
+						} `json:"hits"`
+					} `json:"hits"`
+				} `json:"reservations"`
+			} `json:"buckets"`
+		} `json:"accounts"`
+	}
+
+	// ReservationReport has all the information of an EC2 Coverage report
+	ReservationReport struct {
+		utils.ReportBase
+		Reservation ec2Coverage.Reservation `json:"reservation"`
+	}
+)
+
+// prepareResponseEc2CoverageMonthly parses the results from elasticsearch and returns an array of EC2 Coverage monthly reservations report
+func prepareResponseEc2CoverageMonthly(ctx context.Context, resEc2Coverage *elastic.SearchResult) ([]ReservationReport, error) {
+	logger := jsonlog.LoggerFromContextOrDefault(ctx)
+	var response ResponseEc2CoverageMonthly
+	reservations := make([]ReservationReport, 0)
+	err := json.Unmarshal(*resEc2Coverage.Aggregations["accounts"], &response.Accounts)
+	if err != nil {
+		logger.Error("Error while unmarshaling ES EC2 Coverage response", err)
+		return nil, errors.GetErrorMessage(ctx, err)
+	}
+	for _, account := range response.Accounts.Buckets {
+		for _, reservation := range account.Reservations.Hits.Hits {
+			reservations = append(reservations, ReservationReport{
+				ReportBase:  reservation.Reservation.ReportBase,
+				Reservation: reservation.Reservation.Reservation,
+			})
+		}
+	}
+	return reservations, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -237,8 +237,8 @@
 		{
 			"checksumSHA1": "5ihD2edhf72YLmwWIgwO5nP2WQc=",
 			"path": "github.com/aws/aws-sdk-go/service/costexplorer",
-			"revision": "53eb8b070e9a5067829fd029539966181632032a",
-			"revisionTime": "2018-12-12T23:19:52Z"
+			"revision": "410bbfb2566558b6c4e295406bccb4b9f4523363",
+			"revisionTime": "2018-12-19T00:15:04Z"
 		},
 		{
 			"checksumSHA1": "a4Kb3tBW4zaoS8UFrkfU8MNHE8o=",


### PR DESCRIPTION
Adds an EC2 coverage report based on the Cost Explorer API.
You can get this report on the route `/ec2/coverage` as for EC2 reports.