### PR TITLE
Changed S3 URL to accept bucket name with period.

### DIFF
--- a/aws/s3/rawS3Get.go
+++ b/aws/s3/rawS3Get.go
@@ -68,9 +68,9 @@ func (dm dumbS3Manager) rawS3GetObjectToReader(ctx context.Context, client *http
 // object.
 func (dm dumbS3Manager) rawS3GetObject(region, bucket, key string) (*http.Request, error) {
 	url := fmt.Sprintf(
-		"https://%s.s3.%s.amazonaws.com/%s",
-		bucket,
+		"https://s3.%s.amazonaws.com/%s/%s",
 		region,
+		bucket,
 		rest.EscapePath(key, false),
 	)
 	request, err := http.NewRequest(


### PR DESCRIPTION
Buckets containing a period in their name was breaking the SSL certificate.

#### From:
https://[BUCKET].s3.[REGION].amazonaws.com/[OBJECT_KEY] 

#### To:
https://s3.[REGION].amazonaws.com/[BUCKET]/[OBJECT_KEY]