### PR TITLE
Anomalies warning instead of log when data not available yet

### DIFF
--- a/server/taskAnomaliesDetection.go
+++ b/server/taskAnomaliesDetection.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"flag"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/trackit/jsonlog"
@@ -70,6 +71,13 @@ func processAnomaliesForAccount(ctx context.Context, aaId int) (err error) {
 		err = registerAnomaliesUpdate(tx, lastUpdate, aa.Id)
 	}
 	if err != nil && !elastic.IsNotFound(err) {
+		if strings.HasPrefix(err.Error(), "Data not available yet") {
+			logger.Warning("Failed to detect anomalies.", map[string]interface{}{
+				"awsAccountId": aaId,
+				"error":        err.Error(),
+			})
+			return
+		}
 		logger.Error("Failed to detect anomalies.", map[string]interface{}{
 			"awsAccountId": aaId,
 			"error":        err.Error(),


### PR DESCRIPTION
This PR updates the anomalies task to log a warning instead of an error when the data is not available yet