### PR TITLE
Increase 	MaxCheckedKeysByRepository to fix import issues with big accounts

### DIFF
--- a/aws/s3/readBills.go
+++ b/aws/s3/readBills.go
@@ -42,7 +42,7 @@ const (
 	// other keys, we don't to spend too much time reading the metadata of all
 	// keys. This means that it is the responsibility of the user to put their
 	// bills in a place where there isn't much of anything else.
-	MaxCheckedKeysByRepository = 1000
+	MaxCheckedKeysByRepository = 10000
 
 	ReadBillsStsSessionName = "read-bills"
 )


### PR DESCRIPTION
This PR increases the MaxCheckedKeysByRepository to 10000 to fix import issues with big accounts.
For some accounts, the previous value (1000) was not big enough to find the next manifest, setting it to 10000 should be enough for most cases.