### PR TITLE
Fix unexpected EOF mysql

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -36,6 +36,7 @@ var Db *sql.DB
 func init() {
 	fatalIfError(initDb())
 	fatalIfError(attemptDbConnection())
+	Db.SetMaxIdleConns(0)
 }
 
 func fatalIfError(err error) {


### PR DESCRIPTION
This PR fixes the mysql unexpected EOF error that happens randomly on some endpoints (on the /login endpoint for example).

It prevents go-mysql-driver from keeping idle connections in the connection pool, which can create issues when mysql server closes a connection while it's still in the connection pool.