### PR TITLE
Fixed anomaly detection date range when lastUpdate is abnormal

### DIFF
--- a/anomaliesDetection/products_recurrence.go
+++ b/anomaliesDetection/products_recurrence.go
@@ -1,0 +1,1 @@
+package anomalies


### PR DESCRIPTION
`LastUpdate` can be at `0000-00-00` or `1970-01-01` in the DB, this PR will handle every case.