### PR TITLE
ElasticSearch upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $> docker-compose up -d -f docker/docker-compose.yml
 $> mkdir -p $HOME/go/src/github.com/trackit
 $> cd $HOME/go/src/github.com/trackit
 $> git clone https://github.com/trackit/trackit
-$> cd trackit-server
+$> cd trackit
 ````
 
 #### 2. Check out dependencies

--- a/anomaliesDetection/anomalies.go
+++ b/anomaliesDetection/anomalies.go
@@ -20,8 +20,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws"
 	"github.com/trackit/trackit/aws/s3"

--- a/anomaliesDetection/es_request_constructor.go
+++ b/anomaliesDetection/es_request_constructor.go
@@ -17,7 +17,7 @@ package anomalies
 import (
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/trackit/trackit/config"
 )

--- a/aws/decorators.go
+++ b/aws/decorators.go
@@ -1,15 +1,15 @@
 package aws
 
 import (
-	"net/http"
 	"database/sql"
 	"errors"
+	"net/http"
 
 	"github.com/trackit/jsonlog"
 
+	"github.com/trackit/trackit/db"
 	"github.com/trackit/trackit/routes"
 	"github.com/trackit/trackit/users"
-	"github.com/trackit/trackit/db"
 )
 
 // RequireAwsAccount decorates handler to require that an AwsAccount be

--- a/aws/external.go
+++ b/aws/external.go
@@ -73,8 +73,8 @@ func generateExternal() string {
 	var remainingBits uint64
 	for i := range b {
 	top:
-	// For performance reasons, we use all bits from the random
-	// uint64 before generating a new one.
+		// For performance reasons, we use all bits from the random
+		// uint64 before generating a new one.
 		if remainingBitsCount < externalBitsPerChar {
 			remainingBits = rand.Uint64()
 			remainingBitsCount = 64

--- a/aws/pricings/utils.go
+++ b/aws/pricings/utils.go
@@ -24,7 +24,7 @@ import (
 func getPricingClient() *pricing.Pricing {
 	mySession := session.Must(session.NewSession(&aws.Config{
 		CredentialsChainVerboseErrors: aws.Bool(true),
-		Region: aws.String(PricingApiEndpointRegion),
+		Region:                        aws.String(PricingApiEndpointRegion),
 	}))
 	return pricing.New(mySession)
 }

--- a/aws/routes/routeAwsDelete.go
+++ b/aws/routes/routeAwsDelete.go
@@ -22,12 +22,12 @@ import (
 
 	"github.com/trackit/jsonlog"
 
+	"github.com/trackit/trackit/aws"
 	"github.com/trackit/trackit/db"
 	"github.com/trackit/trackit/es"
 	"github.com/trackit/trackit/models"
 	"github.com/trackit/trackit/routes"
 	"github.com/trackit/trackit/users"
-	"github.com/trackit/trackit/aws"
 )
 
 // DeleteAwsAccountFromAccountID delete an AWS account based on the

--- a/aws/routes/routeAwsPatch.go
+++ b/aws/routes/routeAwsPatch.go
@@ -21,10 +21,10 @@ import (
 
 	"github.com/trackit/jsonlog"
 
+	"github.com/trackit/trackit/aws"
 	"github.com/trackit/trackit/db"
 	"github.com/trackit/trackit/routes"
 	"github.com/trackit/trackit/users"
-	"github.com/trackit/trackit/aws"
 )
 
 // patchAwsAccountRequestBody is all the possible bodies for the

--- a/aws/routes/routeAwsPost.go
+++ b/aws/routes/routeAwsPost.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/trackit/jsonlog"
 
+	"github.com/trackit/trackit/aws"
 	"github.com/trackit/trackit/db"
 	"github.com/trackit/trackit/routes"
 	"github.com/trackit/trackit/users"
-	"github.com/trackit/trackit/aws"
 )
 
 // postAwsAccountRequestBody is the expected request body for the

--- a/aws/s3/ingestBills.go
+++ b/aws/s3/ingestBills.go
@@ -21,9 +21,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/olivere/elastic"
 	"github.com/satori/go.uuid"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws"
 	"github.com/trackit/trackit/es"

--- a/aws/sub_account.go
+++ b/aws/sub_account.go
@@ -91,14 +91,14 @@ func PutSubAccounts(ctx context.Context, account AwsAccount, tx *sql.Tx) error {
 	if err != nil {
 		return err
 	}
-	SubAccountsLoop:
-		for _, sub := range subAccounts {
-			for _, old := range alreadyAccounts {
-				if old.AwsIdentity == sub.AwsIdentity {
-					continue SubAccountsLoop
-				}
+SubAccountsLoop:
+	for _, sub := range subAccounts {
+		for _, old := range alreadyAccounts {
+			if old.AwsIdentity == sub.AwsIdentity {
+				continue SubAccountsLoop
 			}
-			sub.CreateAwsAccount(ctx, tx)
 		}
+		sub.CreateAwsAccount(ctx, tx)
+	}
 	return updateExistingAccount(ctx, account, subAccounts, tx)
 }

--- a/aws/usageReports/ec2/monthlyReport.go
+++ b/aws/usageReports/ec2/monthlyReport.go
@@ -25,8 +25,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/trackit/jsonlog"
 	"github.com/olivere/elastic"
+	"github.com/trackit/jsonlog"
 
 	taws "github.com/trackit/trackit/aws"
 	"github.com/trackit/trackit/aws/usageReports"

--- a/aws/usageReports/ec2/monthlyReport.go
+++ b/aws/usageReports/ec2/monthlyReport.go
@@ -26,7 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	taws "github.com/trackit/trackit/aws"
 	"github.com/trackit/trackit/aws/usageReports"

--- a/aws/usageReports/history/history.go
+++ b/aws/usageReports/history/history.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/trackit/trackit/aws"
 	"github.com/trackit/trackit/aws/usageReports"

--- a/aws/usageReports/history/history.go
+++ b/aws/usageReports/history/history.go
@@ -22,8 +22,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/trackit/jsonlog"
 	"github.com/olivere/elastic"
+	"github.com/trackit/jsonlog"
 
 	"github.com/trackit/trackit/aws"
 	"github.com/trackit/trackit/aws/usageReports"

--- a/aws/usageReports/utils.go
+++ b/aws/usageReports/utils.go
@@ -23,8 +23,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	taws "github.com/trackit/trackit/aws"
 	"github.com/trackit/trackit/es"

--- a/cache/decorator.go
+++ b/cache/decorator.go
@@ -49,19 +49,19 @@ var mainClient *redis.Client
 
 func init() {
 	mainClient = redis.NewClient(&redis.Options{
-		Addr:         config.RedisAddress,
-		Password:     config.RedisPassword,
-		DB:           1,
+		Addr:        config.RedisAddress,
+		Password:    config.RedisPassword,
+		DB:          1,
 		IdleTimeout: -1,
 	})
 	_, err := mainClient.Ping().Result()
 	if err != nil {
-		jsonlog.DefaultLogger.Error("Unable to establish the connection to redis server", map[string] interface{} {
+		jsonlog.Error("Unable to establish the connection to redis server", map[string]interface{}{
 			"error": err.Error(),
 		})
 		os.Exit(1)
 	}
-	jsonlog.DefaultLogger.Info("Successfully connected to redis client", map[string] interface{} {
+	jsonlog.Info("Successfully connected to redis client", map[string]interface{}{
 		"address": config.RedisAddress,
 	})
 }
@@ -83,7 +83,7 @@ func (uc UsersCache) getFunc(hf routes.HandlerFunc) routes.HandlerFunc {
 		}
 		rdCache, err := initialiseCacheInfos(request.URL.String(), args, logger)
 		if err != nil {
-			logger.Error("Error during cache initialization", map[string] interface{} {
+			logger.Error("Error during cache initialization", map[string]interface{}{
 				"error": err.Error(),
 			})
 			writeHeaderCacheStatus(writer, cacheStatusError, "ERROR-INITIALIZATION")
@@ -93,7 +93,7 @@ func (uc UsersCache) getFunc(hf routes.HandlerFunc) routes.HandlerFunc {
 		if userHasCacheForService(rdCache, logger) {
 			retrieveCache := getUserCache(rdCache, logger)
 			if retrieveCache == nil {
-				logger.Warning("Unable to retrieve cache, skipping it to avoid panic or error. The cache has been deleted.", map[string] interface{} {
+				logger.Warning("Unable to retrieve cache, skipping it to avoid panic or error. The cache has been deleted.", map[string]interface{}{
 					"userKey": rdCache.key,
 					"route":   rdCache.route,
 				})

--- a/cache/decorator_test.go
+++ b/cache/decorator_test.go
@@ -26,15 +26,15 @@ const (
 	testArgs     = "date=2019-07-02"
 	testAwsAcc   = "394125495069"
 
-	testKey      = "KEY"
-	testContent  = "This is the content I like"
+	testKey     = "KEY"
+	testContent = "This is the content I like"
 )
 
 func TestGetUserKey(test *testing.T) {
 	result := getUserKey(redisCache{
 		route:      testRoute,
 		args:       testArgs,
-		awsAccount: []string {testAwsAcc},
+		awsAccount: []string{testAwsAcc},
 	})
 	excepted := fmt.Sprintf("%x-%x:%v:", md5.Sum([]byte(testRoute)), md5.Sum([]byte(testArgs)), testAwsAcc)
 	if result != excepted {

--- a/cache/header.go
+++ b/cache/header.go
@@ -31,7 +31,7 @@ const (
 	cacheStatusError
 	cacheStatusInvalid
 
-	cacheHeaderAbsent  // Internal utilisation only
+	cacheHeaderAbsent // Internal utilisation only
 
 	cacheStatusKey    = "Cache-Status"
 	cacheStatusErrKey = "Cache-Error"
@@ -39,7 +39,7 @@ const (
 
 // Keywords corresponding to each cache status.
 // The front-end can only request the cache to be deleted with the keyword "DELETE".
-var cacheHeaderStatus = map[int] string {
+var cacheHeaderStatus = map[int]string{
 	cacheStatusCreated: "CREATED",
 	cacheStatusUsed:    "USED",
 	cacheStatusDelete:  "DELETE",

--- a/cache/local.go
+++ b/cache/local.go
@@ -47,10 +47,10 @@ func parseRouteFromUrl(url string, rc *redisCache) {
 		rc.route = url
 	} else {
 		// The main purpose is to sort arguments by alphabetical order.
-		rc.route = url[:idx] // Cut the first part from the URL which is the route
-		sortedArgs := strings.Split(url[idx + 1:], "&") // Extract, as a strings array, every arguments with their respective values separate by a '&'
-		sort.Strings(sortedArgs) // Sort the strings by alphabetical order, it's important for the key
-		rc.args = strings.Join(sortedArgs, "&") // Convert from the an array of strings to a single strings and join every part by a '&' like initially
+		rc.route = url[:idx]                          // Cut the first part from the URL which is the route
+		sortedArgs := strings.Split(url[idx+1:], "&") // Extract, as a strings array, every arguments with their respective values separate by a '&'
+		sort.Strings(sortedArgs)                      // Sort the strings by alphabetical order, it's important for the key
+		rc.args = strings.Join(sortedArgs, "&")       // Convert from the an array of strings to a single strings and join every part by a '&' like initially
 	}
 }
 
@@ -60,7 +60,7 @@ func parseRouteFromUrl(url string, rc *redisCache) {
 func getAwsIdentityFromSharedAcc(user users.User, identities *[]string, context *sql.Tx, logger jsonlog.Logger) error {
 	sharedAcc, err := models.SharedAccountsByUserID(db.Db, user.Id)
 	if err != nil {
-		logger.Error("Unable to retrieve AWS' shared accounts by user id.", map[string] interface{} {
+		logger.Error("Unable to retrieve AWS' shared accounts by user id.", map[string]interface{}{
 			"error":  err.Error(),
 			"userId": user.Id,
 		})
@@ -69,7 +69,7 @@ func getAwsIdentityFromSharedAcc(user users.User, identities *[]string, context 
 	for _, sharedAccContent := range sharedAcc {
 		localAcc, localErr := models.AwsAccountByID(context, sharedAccContent.AccountID)
 		if localErr != nil {
-			logger.Error("Unable to retrieve AWS' account by shared user id.", map[string] interface{} {
+			logger.Error("Unable to retrieve AWS' account by shared user id.", map[string]interface{}{
 				"error":     localErr.Error(),
 				"accountID": sharedAccContent.AccountID,
 			})
@@ -93,7 +93,7 @@ func initialiseCacheInfos(url string, args routes.Arguments, logger jsonlog.Logg
 		user := args[users.AuthenticatedUser].(users.User)
 		awsAccs, awsAccsErr := models.AwsAccountsByUserID(tx, user.Id)
 		if awsAccsErr != nil {
-			logger.Error("Unable to retrieve AWS' accounts by user id.", map[string] interface{} {
+			logger.Error("Unable to retrieve AWS' accounts by user id.", map[string]interface{}{
 				"error":  awsAccsErr.Error(),
 				"userId": user.Id,
 			})

--- a/cache/utils.go
+++ b/cache/utils.go
@@ -23,7 +23,7 @@ import (
 func userHasCacheForService(rdCache redisCache, logger jsonlog.Logger) bool {
 	rtn, err := mainClient.Exists(rdCache.key).Result()
 	if err != nil {
-		logger.Error("Unable to check if the key already exists in redis.", map[string] interface{} {
+		logger.Error("Unable to check if the key already exists in redis.", map[string]interface{}{
 			"error":   err.Error(),
 			"userKey": rdCache.key,
 		})
@@ -52,7 +52,7 @@ func getUserCache(rdCache redisCache, logger jsonlog.Logger) interface{} {
 
 func createUserCache(rdCache redisCache, data interface{}, logger jsonlog.Logger) {
 	if userHasCacheForService(rdCache, logger) {
-		logger.Warning("The user has already a cache attributed for the current route.", map[string] interface{} {
+		logger.Warning("The user has already a cache attributed for the current route.", map[string]interface{}{
 			"userKey":   rdCache.key,
 			"route":     rdCache.route,
 			"routeArgs": rdCache.args,
@@ -63,17 +63,17 @@ func createUserCache(rdCache redisCache, data interface{}, logger jsonlog.Logger
 	var err error
 	rdCache.cacheContent, err = json.Marshal(data)
 	if err != nil {
-		logger.Error("Unable to marshal API content to create cache.", map[string] interface{} {
+		logger.Error("Unable to marshal API content to create cache.", map[string]interface{}{
 			"error":   err.Error(),
 			"userKey": rdCache.key,
 		})
 		return
 	}
 	cmdStat := mainClient.Append(rdCache.key, string(rdCache.cacheContent))
-	if cmdStat.Err() == nil{
+	if cmdStat.Err() == nil {
 		mainClient.Expire(rdCache.key, cacheExpireTime)
 	} else {
-		logger.Error("Unable to append content.", map[string] interface{} {
+		logger.Error("Unable to append content.", map[string]interface{}{
 			"error":   cmdStat.Err().Error(),
 			"userKey": rdCache.key,
 		})
@@ -83,7 +83,7 @@ func createUserCache(rdCache redisCache, data interface{}, logger jsonlog.Logger
 func deleteUserCache(rdCache redisCache, logger jsonlog.Logger) {
 	rtn := mainClient.Del(rdCache.key)
 	if rtn.Err() != nil {
-		logger.Error("Unable to delete user's cache.", map[string] interface{} {
+		logger.Error("Unable to delete user's cache.", map[string]interface{}{
 			"error":   rtn.Err().Error(),
 			"userKey": rdCache.key,
 		})

--- a/costs/anomalies/anomalies_route.go
+++ b/costs/anomalies/anomalies_route.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/anomaliesDetection"
 	"github.com/trackit/trackit/cache"

--- a/costs/anomalies/es_request_constructor.go
+++ b/costs/anomalies/es_request_constructor.go
@@ -17,7 +17,7 @@ package anomalies
 import (
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 const (

--- a/costs/costs_route.go
+++ b/costs/costs_route.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/s3"
 	"github.com/trackit/trackit/cache"

--- a/costs/diff/diff.go
+++ b/costs/diff/diff.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strconv"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/trackit/jsonlog"
 	"github.com/trackit/trackit/errors"

--- a/costs/diff/diff_route.go
+++ b/costs/diff/diff_route.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws"
 	"github.com/trackit/trackit/aws/s3"

--- a/costs/diff/es_request_constructor.go
+++ b/costs/diff/es_request_constructor.go
@@ -17,7 +17,7 @@ package diff
 import (
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 // aggregationMaxSize is the maximum size of an Elastic Search Aggregation

--- a/costs/es_request_constructor.go
+++ b/costs/es_request_constructor.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 // aggregationBuilder is an alias for the function type that is used in the

--- a/costs/es_request_constructor_test.go
+++ b/costs/es_request_constructor_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 func createAndConfigureTestClient(t *testing.T) *elastic.Client {

--- a/costs/tags/tags_keys.go
+++ b/costs/tags/tags_keys.go
@@ -21,8 +21,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/errors"
 	"github.com/trackit/trackit/es"
@@ -91,7 +91,7 @@ func makeElasticSearchRequestForTagsKeys(ctx context.Context, params tagsKeysQue
 			return nil, http.StatusOK, err
 		} else if cast, ok := err.(*elastic.Error); ok && cast.Details.Type == "search_phase_execution_exception" {
 			l.Error("Error while getting data from ES", map[string]interface{}{
-				"type": fmt.Sprintf("%T", err),
+				"type":  fmt.Sprintf("%T", err),
 				"error": err,
 			})
 		} else {

--- a/costs/tags/tags_values.go
+++ b/costs/tags/tags_values.go
@@ -21,8 +21,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/errors"
 	"github.com/trackit/trackit/es"
@@ -57,7 +57,7 @@ type (
 		Buckets []struct {
 			Time string      `json:"key_as_string"`
 			Item interface{} `json:"key"`
-			Cost    struct {
+			Cost struct {
 				Value float64 `json:"value"`
 			} `json:"cost"`
 		} `json:"buckets"`
@@ -134,7 +134,7 @@ func makeElasticSearchRequestForTagsValues(ctx context.Context, params tagsValue
 		aggregation = elastic.NewReverseNestedAggregation().
 			SubAggregation("filter", elastic.NewDateHistogramAggregation().
 				Field("usageStartDate").MinDocCount(0).Interval(filter.Filter).
-					SubAggregation("cost", elastic.NewSumAggregation().Field("unblendedCost")))
+				SubAggregation("cost", elastic.NewSumAggregation().Field("unblendedCost")))
 	}
 	search := client.Search().Index(index).Size(0).Query(query)
 	search.Aggregation("data", elastic.NewNestedAggregation().Path("tags").
@@ -151,7 +151,7 @@ func makeElasticSearchRequestForTagsValues(ctx context.Context, params tagsValue
 			return nil, http.StatusOK, err
 		} else if cast, ok := err.(*elastic.Error); ok && cast.Details.Type == "search_phase_execution_exception" {
 			l.Error("Error while getting data from ES", map[string]interface{}{
-				"type": fmt.Sprintf("%T", err),
+				"type":  fmt.Sprintf("%T", err),
 				"error": err,
 			})
 		} else {
@@ -185,14 +185,14 @@ func createQueryAccountFilter(accountList []string) *elastic.TermsQuery {
 // getTagsValuesFilter returns a string of the field to filter
 func getTagsValuesFilter(filter string) FilterType {
 	var filters = map[string]FilterType{
-		"product":          {"productCode",     "term"},
-		"region":           {"region",          "term"},
-		"account":          {"usageAccountId",  "term"},
-		"availabilityzone": {"availabilityZone","term"},
-		"day":              {"day",             "time"},
-		"week":             {"week",            "time"},
-		"month":            {"month",           "time"},
-		"year":             {"year",            "time"},
+		"product":          {"productCode", "term"},
+		"region":           {"region", "term"},
+		"account":          {"usageAccountId", "term"},
+		"availabilityzone": {"availabilityZone", "term"},
+		"day":              {"day", "time"},
+		"week":             {"week", "time"},
+		"month":            {"month", "time"},
+		"year":             {"year", "time"},
 	}
 	for i := range filters {
 		if i == filter {

--- a/errors/database.go
+++ b/errors/database.go
@@ -52,7 +52,7 @@ func getDatabaseErrorMessage(ctx context.Context, err *DatabaseError) error {
 		break
 	default:
 		logger.Error("Error not handled", map[string]interface{}{
-			"type": fmt.Sprintf("%T", err),
+			"type":  fmt.Sprintf("%T", err),
 			"error": err,
 		})
 		formattedErr = errors.New("Internal Error")

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -20,8 +20,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 )
 
 func GetErrorMessage(ctx context.Context, err error) error {

--- a/errors/shared_account.go
+++ b/errors/shared_account.go
@@ -62,7 +62,7 @@ func getSharedAccountErrorMessage(ctx context.Context, err *SharedAccountError) 
 		}
 	default:
 		logger.Error("Error not handled", map[string]interface{}{
-			"type": fmt.Sprintf("%T", err),
+			"type":  fmt.Sprintf("%T", err),
 			"error": err,
 		})
 		formattedErr = errors.New("Internal Error")

--- a/es/awsClientSigner.go
+++ b/es/awsClientSigner.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/olivere/elastic"
 	"github.com/sha1sum/aws_signing_client"
-	"gopkg.in/olivere/elastic.v5"
 )
 
 const (

--- a/es/billingRepository.go
+++ b/es/billingRepository.go
@@ -17,7 +17,6 @@ package es
 import (
 	"context"
 
-	//"github.com/olivere/elastic"
 	"github.com/olivere/elastic"
 )
 

--- a/es/billingRepository.go
+++ b/es/billingRepository.go
@@ -17,7 +17,8 @@ package es
 import (
 	"context"
 
-	"gopkg.in/olivere/elastic.v5"
+	//"github.com/olivere/elastic"
+	"github.com/olivere/elastic"
 )
 
 // CleanBillByBillRepositoryId removes every bills information of a specific bill repository

--- a/es/client.go
+++ b/es/client.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-	"github.com/trackit/jsonlog"
 	"github.com/olivere/elastic"
+	"github.com/trackit/jsonlog"
 
 	"github.com/trackit/trackit/awsSession"
 	"github.com/trackit/trackit/config"

--- a/es/client.go
+++ b/es/client.go
@@ -24,7 +24,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
+	//"github.com/olivere/elastic"
+	"github.com/olivere/elastic"
 
 	"github.com/trackit/trackit/awsSession"
 	"github.com/trackit/trackit/config"

--- a/es/client.go
+++ b/es/client.go
@@ -24,7 +24,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/trackit/jsonlog"
-	//"github.com/olivere/elastic"
 	"github.com/olivere/elastic"
 
 	"github.com/trackit/trackit/awsSession"

--- a/es/simplifyCostsDocument.go
+++ b/es/simplifyCostsDocument.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/trackit/jsonlog"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 // SimplifiedCostsDocument contains the data necessary to show a clean version

--- a/es/simplifyCostsDocument.go
+++ b/es/simplifyCostsDocument.go
@@ -21,9 +21,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/trackit/jsonlog"
-
 	"github.com/olivere/elastic"
+	"github.com/trackit/jsonlog"
 )
 
 // SimplifiedCostsDocument contains the data necessary to show a clean version

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -16,10 +16,10 @@ package mail
 
 import (
 	"context"
-	"net/smtp"
 	"crypto/tls"
 	"fmt"
 	"net"
+	"net/smtp"
 
 	"github.com/trackit/jsonlog"
 
@@ -28,14 +28,14 @@ import (
 
 // Mail contains the data necessary to send a mail.
 type Mail struct {
-	SmtpAddress string
-	SmtpPort string
-	SmtpUser string
+	SmtpAddress  string
+	SmtpPort     string
+	SmtpUser     string
 	SmtpPassword string
-	Sender string
-	Recipient string
-	Subject   string
-	Body      string
+	Sender       string
+	Recipient    string
+	Subject      string
+	Body         string
 }
 
 // SendMail is the easiest way to send a mail.
@@ -91,7 +91,7 @@ func (m Mail) setAuth(client *smtp.Client) error {
 // from the Mail structure.
 func (m Mail) getSmtpClient(ctx context.Context) (*smtp.Client, error) {
 
-	conn, err := net.Dial("tcp", m.SmtpAddress + ":" + m.SmtpPort)
+	conn, err := net.Dial("tcp", m.SmtpAddress+":"+m.SmtpPort)
 	if err != nil {
 		return nil, err
 	}

--- a/mail/mail_test.go
+++ b/mail/mail_test.go
@@ -15,8 +15,8 @@
 package mail
 
 import (
-	"testing"
 	"bytes"
+	"testing"
 )
 
 func TestSendMail(t *testing.T) {
@@ -37,7 +37,7 @@ func TestSendMail(t *testing.T) {
 			"Subject: " + m.Subject + "\r\n" +
 			"\r\n" +
 			"test body!",
-		)
+	)
 	if !bytes.Equal(msg, template) {
 		t.Fatalf("Unexcepted message: (%s) instead of (%s)", msg, template)
 	}

--- a/onDemandToRI/ec2/es_request_constructor.go
+++ b/onDemandToRI/ec2/es_request_constructor.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	terrors "github.com/trackit/trackit/errors"
 	"github.com/trackit/trackit/es"

--- a/plugins/account/core/core.go
+++ b/plugins/account/core/core.go
@@ -19,9 +19,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/olivere/elastic"
 	"github.com/trackit/trackit/aws"
 	"github.com/trackit/trackit/users"
-	"gopkg.in/olivere/elastic.v5"
 )
 
 // AccountPlugin is the struct that defines the variables and functions a plugin

--- a/plugins/account/core/es_request_constructor.go
+++ b/plugins/account/core/es_request_constructor.go
@@ -15,7 +15,7 @@
 package plugins_account_core
 
 import (
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 const maxAggregationSize = 0x7FFFFFFF

--- a/plugins/account/core/prepare_response.go
+++ b/plugins/account/core/prepare_response.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/trackit/jsonlog"
 )

--- a/plugins/account/core/route.go
+++ b/plugins/account/core/route.go
@@ -21,8 +21,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/cache"
 	"github.com/trackit/trackit/db"

--- a/plugins/account/s3Traffic/es_request_constructor.go
+++ b/plugins/account/s3Traffic/es_request_constructor.go
@@ -17,7 +17,7 @@ package plugins_account_s3_traffic
 import (
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 // aggregationMaxSize is the maximum size of an Elastic Search Aggregation

--- a/plugins/account/s3Traffic/parse_es_response.go
+++ b/plugins/account/s3Traffic/parse_es_response.go
@@ -17,8 +17,8 @@ package plugins_account_s3_traffic
 import (
 	"encoding/json"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	core "github.com/trackit/trackit/plugins/account/core"
 )

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -15,8 +15,8 @@
 package plugins
 
 import (
+	_ "github.com/trackit/trackit/plugins/account/networkEc2"
 	_ "github.com/trackit/trackit/plugins/account/s3Traffic"
 	_ "github.com/trackit/trackit/plugins/account/unattachedEIP"
 	_ "github.com/trackit/trackit/plugins/account/unusedEBS"
-	_ "github.com/trackit/trackit/plugins/account/networkEc2"
 )

--- a/s3/costs/es_request_constructor.go
+++ b/s3/costs/es_request_constructor.go
@@ -18,7 +18,7 @@ package costs
 import (
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 // aggregationMaxSize is the maximum size of an Elastic Search Aggregation

--- a/s3/costs/prepare_response.go
+++ b/s3/costs/prepare_response.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 
 	"github.com/trackit/jsonlog"
 	"github.com/trackit/trackit/errors"

--- a/s3/costs/s3_costs_route.go
+++ b/s3/costs/s3_costs_route.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/s3"
 	"github.com/trackit/trackit/cache"

--- a/server/taskAnomaliesDetection.go
+++ b/server/taskAnomaliesDetection.go
@@ -22,8 +22,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/anomaliesDetection"
 	"github.com/trackit/trackit/aws"
@@ -76,13 +76,13 @@ func processAnomaliesForAccount(ctx context.Context, aaId int) (err error) {
 			"error":        err.Error(),
 		})
 	}
-	var affectedRoutes = []string {
+	var affectedRoutes = []string{
 		"/costs/anomalies",
 		"/costs/anomalies/filters",
 		"/costs/anomalies/snooze",
 		"/costs/anomalies/unsnooze",
 	}
-	_ = cache.RemoveMatchingCache(affectedRoutes, []string {aa.AwsIdentity}, logger)
+	_ = cache.RemoveMatchingCache(affectedRoutes, []string{aa.AwsIdentity}, logger)
 	return
 }
 

--- a/server/taskCheckEntitlement.go
+++ b/server/taskCheckEntitlement.go
@@ -22,15 +22,15 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/trackit/jsonlog"
-	"github.com/aws/aws-sdk-go/service/marketplaceentitlementservice"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/marketplaceentitlementservice"
+	"github.com/trackit/jsonlog"
 
-	"github.com/trackit/trackit/db"
-	"github.com/trackit/trackit/config"
-	"github.com/trackit/trackit/models"
 	"github.com/trackit/trackit/awsSession"
+	"github.com/trackit/trackit/config"
+	"github.com/trackit/trackit/db"
+	"github.com/trackit/trackit/models"
 )
 
 // taskCheckEntitlement checks the user Entitlement for AWS Marketplace users
@@ -64,7 +64,7 @@ func taskCheckEntitlement(ctx context.Context) error {
 }
 
 // getUserEntitlement calls getEntitlements function to retrieve specific user entitlement from AWS marketplace.
-func getUserEntitlement(ctx context.Context, customerIdentifier string) ([]*marketplaceentitlementservice.Entitlement, error){
+func getUserEntitlement(ctx context.Context, customerIdentifier string) ([]*marketplaceentitlementservice.Entitlement, error) {
 	svc := marketplaceentitlementservice.New(awsSession.Session)
 	var awsInput marketplaceentitlementservice.GetEntitlementsInput
 	var filter = make(map[string][]*string)
@@ -85,7 +85,7 @@ func getUserEntitlement(ctx context.Context, customerIdentifier string) ([]*mark
 }
 
 // checkUserEntitlement enables entitlement to be checked.
-func checkUserEntitlement(ctx context.Context, cuId string, userId int) (error) {
+func checkUserEntitlement(ctx context.Context, cuId string, userId int) error {
 	var expirationDate time.Time
 	res, err := getUserEntitlement(ctx, cuId)
 	if err != nil {
@@ -100,7 +100,7 @@ func checkUserEntitlement(ctx context.Context, cuId string, userId int) (error) 
 
 // checkExpirationDate compares expiration date given by AWS to current time.
 // According to result, an update is pushed to db.
-func checkExpirationDate(expirationDate time.Time, ctx context.Context, db *sql.DB, userId int) (error) {
+func checkExpirationDate(expirationDate time.Time, ctx context.Context, db *sql.DB, userId int) error {
 	var err error
 	currentTime := time.Now()
 	if expirationDate.After(currentTime) {
@@ -112,7 +112,7 @@ func checkExpirationDate(expirationDate time.Time, ctx context.Context, db *sql.
 }
 
 // updateCustomerEntitlement updates aws customer entitlement according to entitlement value.
-func updateCustomerEntitlement(db *sql.DB, ctx context.Context, userId int, entitlementValue bool) (error) {
+func updateCustomerEntitlement(db *sql.DB, ctx context.Context, userId int, entitlementValue bool) error {
 	dbUser, err := models.UserByID(db, userId)
 	if err != nil {
 		return err

--- a/server/taskIngest.go
+++ b/server/taskIngest.go
@@ -90,14 +90,14 @@ func ingestBillingDataForBillRepository(ctx context.Context, aaId, brId int) (er
 	}
 	updateCompletion(ctx, aaId, brId, db.Db, updateId, err)
 	updateSubAccounts(ctx, aa)
-	var affectedRoutes = []string {
+	var affectedRoutes = []string{
 		"/costs",
 		"/costs/diff",
 		"/costs/tags/keys",
 		"/costs/tags/values",
 		"/s3/costs",
 	}
-	_ = cache.RemoveMatchingCache(affectedRoutes, []string {aa.AwsIdentity}, logger)
+	_ = cache.RemoveMatchingCache(affectedRoutes, []string{aa.AwsIdentity}, logger)
 	return
 }
 

--- a/server/taskIngestDue.go
+++ b/server/taskIngestDue.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/trackit/jsonlog"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/trackit/jsonlog"
 
 	"github.com/trackit/trackit/aws/s3"
 	"github.com/trackit/trackit/db"

--- a/server/taskProcessAccount.go
+++ b/server/taskProcessAccount.go
@@ -91,7 +91,7 @@ func ingestDataForAccount(ctx context.Context, aaId int) (err error) {
 			"error":        err.Error(),
 		})
 	}
-	var affectedRoutes = []string {
+	var affectedRoutes = []string{
 		"/ec2",
 		"/ec2/coverage",
 		"/ec2/unused",
@@ -105,7 +105,7 @@ func ingestDataForAccount(ctx context.Context, aaId int) (err error) {
 		"/ri/ec2",
 		"/ri/rds",
 	}
-	_ = cache.RemoveMatchingCache(affectedRoutes, []string {aa.AwsIdentity}, logger)
+	_ = cache.RemoveMatchingCache(affectedRoutes, []string{aa.AwsIdentity}, logger)
 	return
 }
 

--- a/server/taskProcessAccountPlugins.go
+++ b/server/taskProcessAccountPlugins.go
@@ -82,10 +82,10 @@ func preparePluginsProcessingForAccount(ctx context.Context, aaId int) (err erro
 			"error":        err.Error(),
 		})
 	}
-	var affectedRoutes = []string {
+	var affectedRoutes = []string{
 		"/plugins/results",
 	}
-	_ = cache.RemoveMatchingCache(affectedRoutes, []string {aa.AwsIdentity}, logger)
+	_ = cache.RemoveMatchingCache(affectedRoutes, []string{aa.AwsIdentity}, logger)
 	return
 }
 

--- a/server/taskUpdateAwsIdentity.go
+++ b/server/taskUpdateAwsIdentity.go
@@ -25,7 +25,6 @@ import (
 	"github.com/trackit/trackit/models"
 )
 
-
 func taskUpdateAwsIdentity(ctx context.Context) error {
 	var tx *sql.Tx
 	var err error

--- a/usageReports/ec2/es_request_constructor.go
+++ b/usageReports/ec2/es_request_constructor.go
@@ -17,7 +17,7 @@ package ec2
 import (
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 const maxAggregationSize = 0x7FFFFFFF

--- a/usageReports/ec2/get_ec2_data.go
+++ b/usageReports/ec2/get_ec2_data.go
@@ -17,12 +17,12 @@ package ec2
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
-	"errors"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
 
 	"github.com/trackit/trackit/aws/usageReports/ec2"

--- a/usageReports/ec2/prepare_response.go
+++ b/usageReports/ec2/prepare_response.go
@@ -21,8 +21,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/usageReports"
 	"github.com/trackit/trackit/aws/usageReports/ec2"

--- a/usageReports/ec2Coverage/es_request_constructor.go
+++ b/usageReports/ec2Coverage/es_request_constructor.go
@@ -15,7 +15,7 @@
 package ec2Coverage
 
 import (
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 const maxAggregationSize = 0x7FFFFFFF

--- a/usageReports/ec2Coverage/get_ec2_coverage_data.go
+++ b/usageReports/ec2Coverage/get_ec2_coverage_data.go
@@ -22,8 +22,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/usageReports/ec2Coverage"
 	terrors "github.com/trackit/trackit/errors"

--- a/usageReports/ec2Coverage/prepare_response.go
+++ b/usageReports/ec2Coverage/prepare_response.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/usageReports"
 	"github.com/trackit/trackit/aws/usageReports/ec2Coverage"

--- a/usageReports/elasticache/es_request_constructor.go
+++ b/usageReports/elasticache/es_request_constructor.go
@@ -17,7 +17,7 @@ package elasticache
 import (
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 const maxAggregationSize = 0x7FFFFFFF

--- a/usageReports/elasticache/get_elasticache_data.go
+++ b/usageReports/elasticache/get_elasticache_data.go
@@ -17,13 +17,13 @@ package elasticache
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
-	"errors"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/usageReports/elasticache"
 	terrors "github.com/trackit/trackit/errors"

--- a/usageReports/elasticache/prepare_response.go
+++ b/usageReports/elasticache/prepare_response.go
@@ -21,8 +21,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/usageReports"
 	"github.com/trackit/trackit/aws/usageReports/elasticache"

--- a/usageReports/es/es_request_constructor.go
+++ b/usageReports/es/es_request_constructor.go
@@ -18,7 +18,7 @@ package es
 import (
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 const maxAggregationSize = 0x7FFFFFFF

--- a/usageReports/es/get_es_data.go
+++ b/usageReports/es/get_es_data.go
@@ -17,13 +17,13 @@ package es
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
-	"errors"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	tes "github.com/trackit/trackit/aws/usageReports/es"
 	terrors "github.com/trackit/trackit/errors"

--- a/usageReports/es/prepare_response.go
+++ b/usageReports/es/prepare_response.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"sort"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/usageReports"
 	"github.com/trackit/trackit/aws/usageReports/es"

--- a/usageReports/lambda/es_request_constructor.go
+++ b/usageReports/lambda/es_request_constructor.go
@@ -17,7 +17,7 @@ package lambda
 import (
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 const maxAggregationSize = 0x7FFFFFFF

--- a/usageReports/lambda/get_lambda_data.go
+++ b/usageReports/lambda/get_lambda_data.go
@@ -22,8 +22,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/usageReports/lambda"
 	terrors "github.com/trackit/trackit/errors"

--- a/usageReports/lambda/prepare_response.go
+++ b/usageReports/lambda/prepare_response.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/usageReports"
 	"github.com/trackit/trackit/aws/usageReports/lambda"

--- a/usageReports/rds/es_request_constructor.go
+++ b/usageReports/rds/es_request_constructor.go
@@ -17,7 +17,7 @@ package rds
 import (
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 const maxAggregationSize = 0x7FFFFFFF

--- a/usageReports/rds/get_rds_data.go
+++ b/usageReports/rds/get_rds_data.go
@@ -17,13 +17,13 @@ package rds
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
-	"errors"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/usageReports/rds"
 	terrors "github.com/trackit/trackit/errors"

--- a/usageReports/rds/prepare_response.go
+++ b/usageReports/rds/prepare_response.go
@@ -21,12 +21,12 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
+	"github.com/trackit/trackit/aws/usageReports"
 	"github.com/trackit/trackit/aws/usageReports/rds"
 	"github.com/trackit/trackit/errors"
-	"github.com/trackit/trackit/aws/usageReports"
 )
 
 type (

--- a/usageReports/riEc2/es_request_constructor.go
+++ b/usageReports/riEc2/es_request_constructor.go
@@ -17,7 +17,7 @@ package riEc2
 import (
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 const maxAggregationSize = 0x7FFFFFFF

--- a/usageReports/riEc2/get_ec2_data.go
+++ b/usageReports/riEc2/get_ec2_data.go
@@ -22,8 +22,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/usageReports/riEc2"
 	terrors "github.com/trackit/trackit/errors"

--- a/usageReports/riEc2/prepare_response.go
+++ b/usageReports/riEc2/prepare_response.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/usageReports"
 	"github.com/trackit/trackit/aws/usageReports/riEc2"

--- a/usageReports/riRds/es_request_constructor.go
+++ b/usageReports/riRds/es_request_constructor.go
@@ -17,7 +17,7 @@ package riRds
 import (
 	"time"
 
-	"gopkg.in/olivere/elastic.v5"
+	"github.com/olivere/elastic"
 )
 
 const maxAggregationSize = 0x7FFFFFFF

--- a/usageReports/riRds/get_rds_data.go
+++ b/usageReports/riRds/get_rds_data.go
@@ -22,8 +22,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/usageReports/riRdS"
 	terrors "github.com/trackit/trackit/errors"

--- a/usageReports/riRds/prepare_response.go
+++ b/usageReports/riRds/prepare_response.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
-	"gopkg.in/olivere/elastic.v5"
 
 	"github.com/trackit/trackit/aws/usageReports"
 	"github.com/trackit/trackit/aws/usageReports/riRdS"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -503,8 +503,8 @@
 			"path": "github.com/mohae/deepcopy",
 			"revision": "c48cc78d482608239f6c4c92a4abd87eb8761c90",
 			"revisionTime": "2017-09-29T03:49:55Z"
-        },
-        {
+		},
+		{
 			"checksumSHA1": "3OUEENCNkXU947M3a5abAtk19PA=",
 			"path": "github.com/olivere/elastic",
 			"revision": "2ce6dee3af14e17dc059746a1de4f983169030e9",
@@ -513,7 +513,7 @@
 			"versionExact": "v6.2.21"
 		},
 		{
-			"checksumSHA1": "GIqQ5CxFwtMrfG3yMVwUYRtKRLM=",
+			"checksumSHA1": "bOqP4dqo2VSxOJvYF92a5XTCYMc=",
 			"path": "github.com/olivere/elastic",
 			"revision": "fc3063a8c0686f64e94f4b2c17eb140c06eb6793",
 			"revisionTime": "2018-09-20T17:30:04Z"
@@ -521,21 +521,6 @@
 		{
 			"path": "github.com/olivere/elastic.v6",
 			"revision": ""
-		},
-		{
-			"checksumSHA1": "v/phfIsGFjsgpJqe4BEKbGmMYAY=",
-			"path": "github.com/olivere/elastic/config",
-			"revision": "2ce6dee3af14e17dc059746a1de4f983169030e9",
-			"revisionTime": "2019-06-30T15:32:01Z",
-			"version": "v6",
-			"versionExact": "v6.2.21"
-		},
-		{
-			"checksumSHA1": "AmcqvKDAUGvVsrf8NDCQ/B8cMj4=",
-			"path": "github.com/olivere/elastic/uritemplates",
-			"revision": "89a71b89268052a9ba7a8bd9012fa87bf086c1fd",
-			"revisionTime": "2019-06-30T11:54:38Z"
->>>>>>> cfa4129... ES API Library upgrade to 6.2.21 along with the ES 6.* upgrade + Removed obsolete ES API library + Usage of go fmt almost every folder due to huge amount of files edited.
 		},
 		{
 			"checksumSHA1": "rJab1YdNhQooDiBWNnt7TLWPyBU=",
@@ -554,12 +539,6 @@
 			"path": "github.com/sha1sum/aws_signing_client",
 			"revision": "9088e4c7b34b3174ae879fc975deb18ac62ac8d3",
 			"revisionTime": "2017-05-14T20:27:02Z"
-		},
-		{
-			"checksumSHA1": "UpwKp6oFSNQbJTwaN3oRD/amXLI=",
-			"path": "github.com/tealeg/xlsx",
-			"revision": "f1917addaa283ecd881e40b48173544d4145ea67",
-			"revisionTime": "2018-09-19T08:39:35Z"
 		},
 		{
 			"checksumSHA1": "fXENG3ndXoSruFRlAH+HnfAiN3g=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -503,6 +503,39 @@
 			"path": "github.com/mohae/deepcopy",
 			"revision": "c48cc78d482608239f6c4c92a4abd87eb8761c90",
 			"revisionTime": "2017-09-29T03:49:55Z"
+        },
+        {
+			"checksumSHA1": "3OUEENCNkXU947M3a5abAtk19PA=",
+			"path": "github.com/olivere/elastic",
+			"revision": "2ce6dee3af14e17dc059746a1de4f983169030e9",
+			"revisionTime": "2019-06-30T15:32:01Z",
+			"version": "v6.2.21",
+			"versionExact": "v6.2.21"
+		},
+		{
+			"checksumSHA1": "GIqQ5CxFwtMrfG3yMVwUYRtKRLM=",
+			"path": "github.com/olivere/elastic",
+			"revision": "fc3063a8c0686f64e94f4b2c17eb140c06eb6793",
+			"revisionTime": "2018-09-20T17:30:04Z"
+		},
+		{
+			"path": "github.com/olivere/elastic.v6",
+			"revision": ""
+		},
+		{
+			"checksumSHA1": "v/phfIsGFjsgpJqe4BEKbGmMYAY=",
+			"path": "github.com/olivere/elastic/config",
+			"revision": "2ce6dee3af14e17dc059746a1de4f983169030e9",
+			"revisionTime": "2019-06-30T15:32:01Z",
+			"version": "v6",
+			"versionExact": "v6.2.21"
+		},
+		{
+			"checksumSHA1": "AmcqvKDAUGvVsrf8NDCQ/B8cMj4=",
+			"path": "github.com/olivere/elastic/uritemplates",
+			"revision": "89a71b89268052a9ba7a8bd9012fa87bf086c1fd",
+			"revisionTime": "2019-06-30T11:54:38Z"
+>>>>>>> cfa4129... ES API Library upgrade to 6.2.21 along with the ES 6.* upgrade + Removed obsolete ES API library + Usage of go fmt almost every folder due to huge amount of files edited.
 		},
 		{
 			"checksumSHA1": "rJab1YdNhQooDiBWNnt7TLWPyBU=",
@@ -583,24 +616,6 @@
 			"revisionTime": "2017-10-07T15:42:58Z"
 		},
 		{
-			"checksumSHA1": "GIqQ5CxFwtMrfG3yMVwUYRtKRLM=",
-			"path": "gopkg.in/olivere/elastic.v5",
-			"revision": "fc3063a8c0686f64e94f4b2c17eb140c06eb6793",
-			"revisionTime": "2018-09-20T17:30:04Z"
-		},
-		{
-			"checksumSHA1": "Z/5tTcmNfSOHMkcLDkxN93PQ410=",
-			"path": "gopkg.in/olivere/elastic.v5/config",
-			"revision": "79ff368708b3a2a9da641dc831d95fd0782bf4ef",
-			"revisionTime": "2017-11-24T22:04:31Z"
-		},
-		{
-			"checksumSHA1": "pCApZfp2CeDnWbNVsyzNO62ZUXA=",
-			"path": "gopkg.in/olivere/elastic.v5/uritemplates",
-			"revision": "79ff368708b3a2a9da641dc831d95fd0782bf4ef",
-			"revisionTime": "2017-11-24T22:04:31Z"
-		},
-		{
 			"checksumSHA1": "IrHyX6UdBMWh2ZYHPuJZRGyITX8=",
 			"path": "gopkg.in/rana/ora.v4",
 			"revision": "02c78afd6b5b18edaac96e4f3fc03ac4ceb73320",
@@ -619,5 +634,5 @@
 			"revisionTime": "2017-09-19T05:20:08Z"
 		}
 	],
-	"rootPath": "github.com/trackit/trackit-server"
+	"rootPath": "github.com/trackit/trackit"
 }


### PR DESCRIPTION
ElasticSearch (ES) has been upgraded to 6.8 on staging and will be upgrade to 6.7 on production. Along to this upgrade, the ES library for the API has been updated and older versions has been removed from the `vendor` (for govendor) file.
The tool `go fmt` has been used in almost every folder because of the huge amount of edited files due to the ES library upgrade so, there is a lot of little changes accross the repository.
After a short discussion with @hug33k, there was a mistake in the `README.md` file and has been corrected.