### PR TITLE
[Tags] Adding detailed params to tags

### DIFF
--- a/costs/tags/tags.go
+++ b/costs/tags/tags.go
@@ -75,8 +75,8 @@ var tagsValuesQueryArgs = []routes.QueryArg{
 	routes.DetailedQueryArg,
 }
 
-// tagsValuesQueryParams will store the parsed query params for /tags/values endpoint
-type tagsValuesQueryParams struct {
+// TagsValuesQueryParams will store the parsed query params for /tags/values endpoint
+type TagsValuesQueryParams struct {
 	AccountList []string  `json:"awsAccounts"`
 	IndexList   []string  `json:"indexes"`
 	DateBegin   time.Time `json:"begin"`
@@ -89,7 +89,7 @@ type tagsValuesQueryParams struct {
 // getTagsValues returns tags and their values (cost) based on the query params, in JSON format.
 func getTagsValues(request *http.Request, a routes.Arguments) (int, interface{}) {
 	user := a[users.AuthenticatedUser].(users.User)
-	parsedParams := tagsValuesQueryParams{
+	parsedParams := TagsValuesQueryParams{
 		AccountList: []string{},
 		IndexList:   []string{},
 		DateBegin:   a[tagsValuesQueryArgs[1]].(time.Time),

--- a/costs/tags/tags.go
+++ b/costs/tags/tags.go
@@ -72,6 +72,7 @@ var tagsValuesQueryArgs = []routes.QueryArg{
 		Type:        routes.QueryArgString{},
 		Optional:    false,
 	},
+	routes.DetailedQueryArg,
 }
 
 // tagsValuesQueryParams will store the parsed query params for /tags/values endpoint
@@ -82,6 +83,7 @@ type tagsValuesQueryParams struct {
 	DateEnd     time.Time `json:"end"`
 	TagsKeys    []string  `json:"keys"`
 	By          string    `json:"by"`
+	Detailed    bool      `json:"detailed"`
 }
 
 // getTagsValues returns tags and their values (cost) based on the query params, in JSON format.
@@ -94,6 +96,7 @@ func getTagsValues(request *http.Request, a routes.Arguments) (int, interface{})
 		DateEnd:     a[tagsValuesQueryArgs[2]].(time.Time).Add(time.Hour*time.Duration(23) + time.Minute*time.Duration(59) + time.Second*time.Duration(59)),
 		TagsKeys:    []string{},
 		By:          a[tagsValuesQueryArgs[4]].(string),
+		Detailed:    a[tagsValuesQueryArgs[5]].(bool),
 	}
 	if a[tagsValuesQueryArgs[0]] != nil {
 		parsedParams.AccountList = a[tagsValuesQueryArgs[0]].([]string)

--- a/costs/tags/tags_values.go
+++ b/costs/tags/tags_values.go
@@ -34,12 +34,11 @@ type (
 		Type   string
 	}
 
-
 	// structs that allows to parse ES result
 	esTagsValuesDetailedResult struct {
 		Keys struct {
 			Buckets []struct {
-				Key  string       `json:"key"`
+				Key  string               `json:"key"`
 				Tags esTagsDetailedResult `json:"tags"`
 			} `json:"buckets"`
 		} `json:"keys"`
@@ -90,9 +89,9 @@ type (
 
 	// contain a tag and the list of products associated
 	TagsValues struct {
-		Tag       string             `json:"tag"`
-		Costs     []TagValue         `json:"costs,omitempty"`
-		Items     []TagValueDetailed `json:"items,omitempty"`
+		Tag   string             `json:"tag"`
+		Costs []TagValue         `json:"costs,omitempty"`
+		Items []TagValueDetailed `json:"items,omitempty"`
 	}
 
 	// response format of the endpoint
@@ -100,7 +99,7 @@ type (
 )
 
 // getTagsValuesWithParsedParams will parse the data from ElasticSearch and return it
-func getTagsValuesWithParsedParams(ctx context.Context, params tagsValuesQueryParams) (int, interface{}) {
+func getTagsValuesWithParsedParams(ctx context.Context, params TagsValuesQueryParams) (int, interface{}) {
 	response := TagsValuesResponse{}
 	l := jsonlog.LoggerFromContextOrDefault(ctx)
 	var typedDocument esTagsValuesDetailedResult
@@ -125,7 +124,7 @@ func getTagsValuesWithParsedParams(ctx context.Context, params tagsValuesQueryPa
 }
 
 //getTagsResponseDetailed get response for tagging when detailed is true
-func getTagsResponseDetailed(typedDocument esTagsValuesDetailedResult, params tagsValuesQueryParams) TagsValuesResponse {
+func getTagsResponseDetailed(typedDocument esTagsValuesDetailedResult, params TagsValuesQueryParams) TagsValuesResponse {
 	response := TagsValuesResponse{}
 	for _, key := range typedDocument.Keys.Buckets {
 		var values []TagsValues
@@ -155,7 +154,7 @@ func getTagsResponseDetailed(typedDocument esTagsValuesDetailedResult, params ta
 }
 
 //getTagsResponseDetailed get response for tagging when detailed is false
-func getTagsResponse(typedDocument esTagsValuesDetailedResult, params tagsValuesQueryParams) TagsValuesResponse {
+func getTagsResponse(typedDocument esTagsValuesDetailedResult, params TagsValuesQueryParams) TagsValuesResponse {
 	response := TagsValuesResponse{}
 	for _, key := range typedDocument.Keys.Buckets {
 		var values []TagsValues
@@ -178,7 +177,7 @@ func getTagsResponse(typedDocument esTagsValuesDetailedResult, params tagsValues
 }
 
 //getAggregationForTagsValues get NewReversedNestedAggregation if detailed is true or false
-func getAggregationForTagsValues(params tagsValuesQueryParams, filter FilterType) (aggregation *elastic.ReverseNestedAggregation) {
+func getAggregationForTagsValues(params TagsValuesQueryParams, filter FilterType) (aggregation *elastic.ReverseNestedAggregation) {
 	if params.Detailed == true {
 		aggregation = elastic.NewReverseNestedAggregation().
 			SubAggregation("filter", elastic.NewTermsAggregation().Field(filter.Filter).Size(maxAggregationSize).
@@ -212,7 +211,7 @@ func getAggregationForTagsValues(params tagsValuesQueryParams, filter FilterType
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
 // be returned, but instead of having a 500 status code, it will return the provided status code
 // with empty data
-func makeElasticSearchRequestForTagsValues(ctx context.Context, params tagsValuesQueryParams, client *elastic.Client) (*elastic.SearchResult, int, error) {
+func makeElasticSearchRequestForTagsValues(ctx context.Context, params TagsValuesQueryParams, client *elastic.Client) (*elastic.SearchResult, int, error) {
 	l := jsonlog.LoggerFromContextOrDefault(ctx)
 	filter := getTagsValuesFilter(params.By)
 	query := getTagsValuesQuery(params)
@@ -245,7 +244,7 @@ func makeElasticSearchRequestForTagsValues(ctx context.Context, params tagsValue
 }
 
 // getTagsValuesQuery will generate a query for the ElasticSearch based on params
-func getTagsValuesQuery(params tagsValuesQueryParams) *elastic.BoolQuery {
+func getTagsValuesQuery(params TagsValuesQueryParams) *elastic.BoolQuery {
 	query := elastic.NewBoolQuery()
 	if len(params.AccountList) > 0 {
 		query = query.Filter(createQueryAccountFilter(params.AccountList))

--- a/costs/tags/tags_values.go
+++ b/costs/tags/tags_values.go
@@ -112,9 +112,6 @@ func getTagsValuesWithParsedParams(ctx context.Context, params tagsValuesQueryPa
 		return returnCode, errors.GetErrorMessage(ctx, err)
 	}
 	err = json.Unmarshal(*res.Aggregations["data"], &typedDocument)
-	l.Debug("typedDocument ========", map[string]interface{}{
-		"doc": typedDocument,
-	})
 	if err != nil {
 		l.Error("Error while unmarshaling", err)
 		return http.StatusInternalServerError, errors.GetErrorMessage(ctx, err)
@@ -134,8 +131,8 @@ func getTagsResponseDetailed(typedDocument esTagsValuesDetailedResult, params ta
 		var values []TagsValues
 		for _, tag := range key.Tags.Buckets {
 			var products []TagValueDetailed
-			var valueDetailed []ValueDetailed
 			for _, filter := range tag.Rev.Filter.Buckets {
+				var valueDetailed []ValueDetailed
 				for _, usageType := range filter.Type.Buckets {
 					valueDetailed = append(valueDetailed, ValueDetailed{
 						UsageType: usageType.Key,

--- a/routes/commonQueryArgs.go
+++ b/routes/commonQueryArgs.go
@@ -96,6 +96,16 @@ var (
 		Optional:    false,
 	}
 
+	// DetailedQueryArg allows to get detailed
+	// Parameters with routes.QueryArgs. This type will be a
+	// bool stored in the routes.Arguments map with itself for key.
+	DetailedQueryArg = QueryArg{
+		Name: "detailed",
+		Type:  QueryArgBool{},
+		Description: "The detailed arg",
+		Optional: false,
+	}
+
 	// ReportTypeQueryArg allows to get the report type in the URL
 	// Parameters with routes.QueryArgs. This type will be a
 	// string stored in the routes.Arguments map with itself for key.


### PR DESCRIPTION
Add a new query params "detailed" which is a boolean, if detailed is true, you'll have all the usage types for an AWS product.