### PR TITLE
Add optional parameters to Process Account task

### DIFF
--- a/aws/usageReports/ebs/dailyReport.go
+++ b/aws/usageReports/ebs/dailyReport.go
@@ -72,7 +72,7 @@ func fetchDailySnapshotsList(ctx context.Context, creds *credentials.Credentials
 // FetchDailySnapshotsStats fetches the stats of the EBS snapshots of an AwsAccount
 // to import them in ElasticSearch. The stats are fetched from the last hour.
 // In this way, FetchSnapshotsStats should be called every hour.
-func FetchDailySnapshotsStats(ctx context.Context, awsAccount taws.AwsAccount, now time.Time) error {
+func FetchDailySnapshotsStats(ctx context.Context, awsAccount taws.AwsAccount, date time.Time) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching EBS snapshot stats", map[string]interface{}{"awsAccountId": awsAccount.Id})
 	creds, err := taws.GetTemporaryCredentials(awsAccount, MonitorSnapshotStsSessionName)
@@ -105,7 +105,7 @@ func FetchDailySnapshotsStats(ctx context.Context, awsAccount taws.AwsAccount, n
 		snapshots = append(snapshots, SnapshotReport{
 			ReportBase: utils.ReportBase{
 				Account:    account,
-				ReportDate: now,
+				ReportDate: date,
 				ReportType: "daily",
 			},
 			Snapshot: snapshot,

--- a/aws/usageReports/ebs/dailyReport.go
+++ b/aws/usageReports/ebs/dailyReport.go
@@ -72,7 +72,7 @@ func fetchDailySnapshotsList(ctx context.Context, creds *credentials.Credentials
 // FetchDailySnapshotsStats fetches the stats of the EBS snapshots of an AwsAccount
 // to import them in ElasticSearch. The stats are fetched from the last hour.
 // In this way, FetchSnapshotsStats should be called every hour.
-func FetchDailySnapshotsStats(ctx context.Context, awsAccount taws.AwsAccount) error {
+func FetchDailySnapshotsStats(ctx context.Context, awsAccount taws.AwsAccount, now time.Time) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching EBS snapshot stats", map[string]interface{}{"awsAccountId": awsAccount.Id})
 	creds, err := taws.GetTemporaryCredentials(awsAccount, MonitorSnapshotStsSessionName)
@@ -84,7 +84,6 @@ func FetchDailySnapshotsStats(ctx context.Context, awsAccount taws.AwsAccount) e
 		Credentials: creds,
 		Region:      aws.String(config.AwsRegion),
 	}))
-	now := time.Now().UTC()
 	account, err := utils.GetAccountId(ctx, defaultSession)
 	if err != nil {
 		logger.Error("Error when getting account id", err.Error())

--- a/aws/usageReports/ec2/dailyReport.go
+++ b/aws/usageReports/ec2/dailyReport.go
@@ -71,7 +71,7 @@ func fetchDailyInstancesList(ctx context.Context, creds *credentials.Credentials
 // FetchDailyInstancesStats fetches the stats of the EC2 instances of an AwsAccount
 // to import them in ElasticSearch. The stats are fetched from the last hour.
 // In this way, FetchInstancesStats should be called every hour.
-func FetchDailyInstancesStats(ctx context.Context, awsAccount taws.AwsAccount, now time.Time) error {
+func FetchDailyInstancesStats(ctx context.Context, awsAccount taws.AwsAccount, date time.Time) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching EC2 instance stats", map[string]interface{}{"awsAccountId": awsAccount.Id})
 	creds, err := taws.GetTemporaryCredentials(awsAccount, MonitorInstanceStsSessionName)
@@ -104,7 +104,7 @@ func FetchDailyInstancesStats(ctx context.Context, awsAccount taws.AwsAccount, n
 		instances = append(instances, InstanceReport{
 			ReportBase: utils.ReportBase{
 				Account:    account,
-				ReportDate: now,
+				ReportDate: date,
 				ReportType: "daily",
 			},
 			Instance: instance,

--- a/aws/usageReports/ec2/dailyReport.go
+++ b/aws/usageReports/ec2/dailyReport.go
@@ -71,7 +71,7 @@ func fetchDailyInstancesList(ctx context.Context, creds *credentials.Credentials
 // FetchDailyInstancesStats fetches the stats of the EC2 instances of an AwsAccount
 // to import them in ElasticSearch. The stats are fetched from the last hour.
 // In this way, FetchInstancesStats should be called every hour.
-func FetchDailyInstancesStats(ctx context.Context, awsAccount taws.AwsAccount) error {
+func FetchDailyInstancesStats(ctx context.Context, awsAccount taws.AwsAccount, now time.Time) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching EC2 instance stats", map[string]interface{}{"awsAccountId": awsAccount.Id})
 	creds, err := taws.GetTemporaryCredentials(awsAccount, MonitorInstanceStsSessionName)
@@ -83,7 +83,6 @@ func FetchDailyInstancesStats(ctx context.Context, awsAccount taws.AwsAccount) e
 		Credentials: creds,
 		Region:      aws.String(config.AwsRegion),
 	}))
-	now := time.Now().UTC()
 	account, err := utils.GetAccountId(ctx, defaultSession)
 	if err != nil {
 		logger.Error("Error when getting account id", err.Error())

--- a/aws/usageReports/elasticache/dailyReport.go
+++ b/aws/usageReports/elasticache/dailyReport.go
@@ -71,7 +71,7 @@ func fetchDailyInstancesList(ctx context.Context, creds *credentials.Credentials
 // FetchDailyInstancesStats fetches the stats of the ElastiCache instances of an AwsAccount
 // to import them in ElasticSearch. The stats are fetched from the last hour.
 // In this way, FetchInstancesStats should be called every hour.
-func FetchDailyInstancesStats(ctx context.Context, awsAccount taws.AwsAccount, now time.Time) error {
+func FetchDailyInstancesStats(ctx context.Context, awsAccount taws.AwsAccount, date time.Time) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching ElastiCache instance stats", map[string]interface{}{"awsAccountId": awsAccount.Id})
 	creds, err := taws.GetTemporaryCredentials(awsAccount, MonitorInstanceStsSessionName)
@@ -104,7 +104,7 @@ func FetchDailyInstancesStats(ctx context.Context, awsAccount taws.AwsAccount, n
 		instances = append(instances, InstanceReport{
 			ReportBase: utils.ReportBase{
 				Account:    account,
-				ReportDate: now,
+				ReportDate: date,
 				ReportType: "daily",
 			},
 			Instance: instance,

--- a/aws/usageReports/elasticache/dailyReport.go
+++ b/aws/usageReports/elasticache/dailyReport.go
@@ -71,7 +71,7 @@ func fetchDailyInstancesList(ctx context.Context, creds *credentials.Credentials
 // FetchDailyInstancesStats fetches the stats of the ElastiCache instances of an AwsAccount
 // to import them in ElasticSearch. The stats are fetched from the last hour.
 // In this way, FetchInstancesStats should be called every hour.
-func FetchDailyInstancesStats(ctx context.Context, awsAccount taws.AwsAccount) error {
+func FetchDailyInstancesStats(ctx context.Context, awsAccount taws.AwsAccount, now time.Time) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching ElastiCache instance stats", map[string]interface{}{"awsAccountId": awsAccount.Id})
 	creds, err := taws.GetTemporaryCredentials(awsAccount, MonitorInstanceStsSessionName)
@@ -83,7 +83,6 @@ func FetchDailyInstancesStats(ctx context.Context, awsAccount taws.AwsAccount) e
 		Credentials: creds,
 		Region:      aws.String(config.AwsRegion),
 	}))
-	now := time.Now().UTC()
 	account, err := utils.GetAccountId(ctx, defaultSession)
 	if err != nil {
 		logger.Error("Error when getting account id", err.Error())

--- a/aws/usageReports/es/dailyReport.go
+++ b/aws/usageReports/es/dailyReport.go
@@ -89,7 +89,7 @@ func fetchDailyDomainsList(ctx context.Context, creds *credentials.Credentials, 
 }
 
 // FetchDomainsStats retrieces ES information from the AWS API and generate a report
-func FetchDomainsStats(ctx context.Context, awsAccount taws.AwsAccount) error {
+func FetchDomainsStats(ctx context.Context, awsAccount taws.AwsAccount, now time.Time) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching ES instance stats", map[string]interface{}{"awsAccountId": awsAccount.Id})
 	creds, err := taws.GetTemporaryCredentials(awsAccount, MonitorDomainStsSessionName)
@@ -101,7 +101,6 @@ func FetchDomainsStats(ctx context.Context, awsAccount taws.AwsAccount) error {
 		Credentials: creds,
 		Region:      aws.String(config.AwsRegion),
 	}))
-	now := time.Now().UTC()
 	account, err := utils.GetAccountId(ctx, defaultSession)
 	if err != nil {
 		logger.Error("Error when getting account id", err.Error())

--- a/aws/usageReports/es/dailyReport.go
+++ b/aws/usageReports/es/dailyReport.go
@@ -89,7 +89,7 @@ func fetchDailyDomainsList(ctx context.Context, creds *credentials.Credentials, 
 }
 
 // FetchDomainsStats retrieces ES information from the AWS API and generate a report
-func FetchDomainsStats(ctx context.Context, awsAccount taws.AwsAccount, now time.Time) error {
+func FetchDomainsStats(ctx context.Context, awsAccount taws.AwsAccount, date time.Time) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching ES instance stats", map[string]interface{}{"awsAccountId": awsAccount.Id})
 	creds, err := taws.GetTemporaryCredentials(awsAccount, MonitorDomainStsSessionName)
@@ -122,7 +122,7 @@ func FetchDomainsStats(ctx context.Context, awsAccount taws.AwsAccount, now time
 		domains = append(domains, DomainReport{
 			ReportBase: utils.ReportBase{
 				Account:    account,
-				ReportDate: now,
+				ReportDate: date,
 				ReportType: "daily",
 			},
 			Domain: domain,

--- a/aws/usageReports/lambda/dailyReport.go
+++ b/aws/usageReports/lambda/dailyReport.go
@@ -67,7 +67,7 @@ func fetchDailyFunctionsList(ctx context.Context, creds *credentials.Credentials
 // FetchDailyFunctionsStats fetches the stats of the Lambda functions of an AwsAccount
 // to import them in ElasticSearch. The stats are fetched from the last hour.
 // In this way, FetchFunctionsStats should be called every hour.
-func FetchDailyFunctionsStats(ctx context.Context, awsAccount taws.AwsAccount, now time.Time) error {
+func FetchDailyFunctionsStats(ctx context.Context, awsAccount taws.AwsAccount, date time.Time) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching Lambda function stats", map[string]interface{}{"awsAccountId": awsAccount.Id})
 	creds, err := taws.GetTemporaryCredentials(awsAccount, MonitorFunctionStsSessionName)
@@ -100,7 +100,7 @@ func FetchDailyFunctionsStats(ctx context.Context, awsAccount taws.AwsAccount, n
 		functions = append(functions, FunctionReport{
 			ReportBase: utils.ReportBase{
 				Account:    account,
-				ReportDate: now,
+				ReportDate: date,
 				ReportType: "daily",
 			},
 			Function: function,

--- a/aws/usageReports/lambda/dailyReport.go
+++ b/aws/usageReports/lambda/dailyReport.go
@@ -67,7 +67,7 @@ func fetchDailyFunctionsList(ctx context.Context, creds *credentials.Credentials
 // FetchDailyFunctionsStats fetches the stats of the Lambda functions of an AwsAccount
 // to import them in ElasticSearch. The stats are fetched from the last hour.
 // In this way, FetchFunctionsStats should be called every hour.
-func FetchDailyFunctionsStats(ctx context.Context, awsAccount taws.AwsAccount) error {
+func FetchDailyFunctionsStats(ctx context.Context, awsAccount taws.AwsAccount, now time.Time) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching Lambda function stats", map[string]interface{}{"awsAccountId": awsAccount.Id})
 	creds, err := taws.GetTemporaryCredentials(awsAccount, MonitorFunctionStsSessionName)
@@ -79,7 +79,6 @@ func FetchDailyFunctionsStats(ctx context.Context, awsAccount taws.AwsAccount) e
 		Credentials: creds,
 		Region:      aws.String(config.AwsRegion),
 	}))
-	now := time.Now().UTC()
 	account, err := utils.GetAccountId(ctx, defaultSession)
 	if err != nil {
 		logger.Error("Error when getting account id", err.Error())

--- a/aws/usageReports/riEc2/dailyReport.go
+++ b/aws/usageReports/riEc2/dailyReport.go
@@ -72,7 +72,7 @@ func fetchDailyReservationsList(ctx context.Context, creds *credentials.Credenti
 // FetchDailyReservationsStats fetches the stats of the reserved instances of an AwsAccount
 // to import them in ElasticSearch. The stats are fetched from the last hour.
 // In this way, FetchReservationsStats should be called every hour.
-func FetchDailyReservationsStats(ctx context.Context, awsAccount taws.AwsAccount) error {
+func FetchDailyReservationsStats(ctx context.Context, awsAccount taws.AwsAccount, now time.Time) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching ReservedInstances reservation stats", map[string]interface{}{"awsAccountId": awsAccount.Id})
 	creds, err := taws.GetTemporaryCredentials(awsAccount, MonitorReservationStsSessionName)
@@ -84,7 +84,6 @@ func FetchDailyReservationsStats(ctx context.Context, awsAccount taws.AwsAccount
 		Credentials: creds,
 		Region:      aws.String(config.AwsRegion),
 	}))
-	now := time.Now().UTC()
 	account, err := utils.GetAccountId(ctx, defaultSession)
 	if err != nil {
 		logger.Error("Error when getting account id", err.Error())

--- a/aws/usageReports/riRdS/dailyReport.go
+++ b/aws/usageReports/riRdS/dailyReport.go
@@ -68,7 +68,7 @@ func fetchDailyInstancesList(ctx context.Context, creds *credentials.Credentials
 }
 
 // FetchDailyInstanceStats retrieves RDS information from the AWS API and generates a report
-func FetchDailyInstancesStats(ctx context.Context, aa taws.AwsAccount) error {
+func FetchDailyInstancesStats(ctx context.Context, aa taws.AwsAccount, now time.Time) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching Reserved RDS instance stats", map[string]interface{}{"awsAccountId": aa.Id})
 	creds, err := taws.GetTemporaryCredentials(aa, RDSStsSessionName)
@@ -80,7 +80,6 @@ func FetchDailyInstancesStats(ctx context.Context, aa taws.AwsAccount) error {
 		Credentials: creds,
 		Region:      aws.String(config.AwsRegion),
 	}))
-	now := time.Now().UTC()
 	account, err := utils.GetAccountId(ctx, defaultSession)
 	if err != nil {
 		logger.Error("Error when getting account id", err.Error())

--- a/onDemandToRI/ec2/report.go
+++ b/onDemandToRI/ec2/report.go
@@ -297,11 +297,11 @@ func calculateCosts(ctx context.Context, unreservedIntances []InstancesSpecs, ec
 // RunOnDemandToRiEc2 generates a report listing the unreserved instances and the
 // savings that can be done by buying reservations
 // The result is saved into ES
-func RunOnDemandToRiEc2(ctx context.Context, aa aws.AwsAccount) error {
+func RunOnDemandToRiEc2(ctx context.Context, aa aws.AwsAccount, now time.Time) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	report := OdToRiEc2Report{
 		Account:    aa.AwsIdentity,
-		ReportDate: time.Now().UTC(),
+		ReportDate: now,
 	}
 	logger.Info("Generating on demand to reserved instances EC2 report", map[string]interface{}{"awsAccountId": aa.Id})
 	reservationsReport, err := getRIReport(ctx, aa)

--- a/server/taskProcessAccount.go
+++ b/server/taskProcessAccount.go
@@ -103,7 +103,7 @@ func ingestDataForAccount(ctx context.Context, aaId int, date time.Time) (err er
 	} else if updateId, err = registerAccountProcessing(db.Db, aa); err != nil {
 	} else {
 		ec2Err := processAccountEC2(ctx, aa, date)
-		rdsErr := processAccountRDS(ctx, aa, date)
+		rdsErr := processAccountRDS(ctx, aa)
 		esErr := processAccountES(ctx, aa, date)
 		elastiCacheErr := processAccountElastiCache(ctx, aa, date)
 		lambdaErr := processAccountLambda(ctx, aa, date)
@@ -200,7 +200,7 @@ func registerAccountProcessingCompletion(db *sql.DB, updateId int64, jobErr, rds
 }
 
 // processAccountRDS processes all the RDS data for an AwsAccount
-func processAccountRDS(ctx context.Context, aa aws.AwsAccount, date time.Time) error {
+func processAccountRDS(ctx context.Context, aa aws.AwsAccount) error {
 	err := rds.FetchDailyInstancesStats(ctx, aa)
 	if err != nil {
 		logger := jsonlog.LoggerFromContextOrDefault(ctx)


### PR DESCRIPTION
The task to ingest account data can now take 2 optional parameters. It allow to ingest data at a specific month & year like master spreadsheet task does.