### PR TITLE
Removed month before for limit ingestion

### DIFF
--- a/aws/s3/ingestBills.go
+++ b/aws/s3/ingestBills.go
@@ -214,7 +214,7 @@ func ingestLineItems(ctx context.Context, bp *elastic.BulkProcessor, index strin
 func manifestsModifiedAfter(t time.Time) ManifestPredicate {
 	return func(m manifest, oneMonthBefore bool) bool {
 		if oneMonthBefore {
-			if time.Time(m.LastModified).AddDate(0, 1, 0).After(t) {
+			if time.Time(m.LastModified).After(t) {
 				return true
 			} else {
 				return false


### PR DESCRIPTION
This removes the requirement of ingesting the last month when using task `ingest-limit`