### PR TITLE
Merge error logs & lambda mapping fix to master

### DIFF
--- a/anomaliesDetection/products.go
+++ b/anomaliesDetection/products.go
@@ -230,6 +230,7 @@ func productGetAnomaliesData(ctx context.Context, params AnomalyEsQueryParams) (
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	sr, err := makeElasticSearchRequest(ctx, getProductElasticSearchParams, params)
 	if err != nil {
+		logger.Error("Failed to make elasticsearch request.", err.Error())
 		return nil, err
 	}
 	var typedDocument esProductTypedResult

--- a/aws/usageReports/lambda/dailyReport.go
+++ b/aws/usageReports/lambda/dailyReport.go
@@ -25,7 +25,7 @@ import (
 	"github.com/trackit/jsonlog"
 
 	taws "github.com/trackit/trackit/aws"
-	"github.com/trackit/trackit/aws/usageReports"
+	utils "github.com/trackit/trackit/aws/usageReports"
 	"github.com/trackit/trackit/config"
 )
 
@@ -56,6 +56,7 @@ func fetchDailyFunctionsList(ctx context.Context, creds *credentials.Credentials
 				Runtime:      aws.StringValue(function.Runtime),
 				Size:         aws.Int64Value(function.CodeSize),
 				Memory:       aws.Int64Value(function.MemorySize),
+				Region:       region,
 			},
 			Tags:  getFunctionTags(ctx, function, svc),
 			Stats: stats,

--- a/aws/usageReports/lambda/mappings.go
+++ b/aws/usageReports/lambda/mappings.go
@@ -42,7 +42,7 @@ func init() {
 const TemplateLineItem = `
 {
 	"template": "*-lambda-reports",
-	"version": 1,
+	"version": 2,
 	"mappings": {
 		"lambda-report": {
 			"properties": {

--- a/aws/usageReports/lambda/mappings.go
+++ b/aws/usageReports/lambda/mappings.go
@@ -63,6 +63,15 @@ const TemplateLineItem = `
 						"description": {
 							"type": "keyword"
 						},
+						"version": {
+							"type": "keyword"
+						},
+						"lastModified": {
+							"type": "keyword"
+						},
+						"runtime": {
+							"type": "keyword"
+						},
 						"size": {
 							"type": "integer"
 						},

--- a/aws/usageReports/lambda/mappings.go
+++ b/aws/usageReports/lambda/mappings.go
@@ -69,6 +69,9 @@ const TemplateLineItem = `
 						"memory": {
 							"type": "integer"
 						},
+						"region": {
+							"type": "keyword"
+						},
 						"tags": {
 							"type": "nested",
 							"properties": {

--- a/aws/usageReports/lambda/utils.go
+++ b/aws/usageReports/lambda/utils.go
@@ -25,7 +25,7 @@ import (
 	"github.com/trackit/jsonlog"
 
 	taws "github.com/trackit/trackit/aws"
-	"github.com/trackit/trackit/aws/usageReports"
+	utils "github.com/trackit/trackit/aws/usageReports"
 	"github.com/trackit/trackit/es"
 )
 
@@ -47,6 +47,7 @@ type (
 		Runtime      string `json:"runtime"`
 		Size         int64  `json:"size"`
 		Memory       int64  `json:"memory"`
+		Region       string `json:"region"`
 	}
 
 	// Function contains all the information of an Lambda function


### PR DESCRIPTION
Lambda mapping works correctly on staging, when you create an account, new fields are correctly mapped. Old lambda index mappings were manually fixed on staging & prod.