### PR TITLE
Fixed indexing tagging reports of all AWS account of a user

### DIFF
--- a/tagging/ebs/es.go
+++ b/tagging/ebs/es.go
@@ -50,21 +50,33 @@ func queryEs(ctx context.Context, indexName string) (*elastic.SearchResult, erro
 	index := client.Search().Index(indexName)
 	filter := elastic.NewBoolQuery().Must(elastic.NewTermQuery("reportType", "daily"))
 	return index.Size(0).Query(filter).
-		Aggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
-			SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
-				Include("account", "snapshot.id", "snapshot.region", "snapshot.tags")))).Do(ctx)
+		Aggregation("accounts", elastic.NewTermsAggregation().Field("account").Size(2147483647).
+			SubAggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
+				SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
+					Include("account", "snapshot.id", "snapshot.region", "snapshot.tags"))))).Do(ctx)
 }
 
 func processSearchResult(res *elastic.SearchResult) ([]*elastic.SearchHit, error) {
-	reportDateAggregationRes, found := res.Aggregations.Terms("reportDate")
-	if !found || len(reportDateAggregationRes.Buckets) <= 0 {
-		return nil, errors.New("could not query elastic search")
-	}
-
-	topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+	accountAggregationRes, found := res.Aggregations.Terms("accounts")
 	if !found {
 		return nil, errors.New("could not query elastic search")
 	}
 
-	return topHitsAggregationRes.Hits.Hits, nil
+	results := []*elastic.SearchHit{}
+
+	for _, accountBucket := range accountAggregationRes.Buckets {
+		reportDateAggregationRes, found := accountBucket.Aggregations.Terms("reportDate")
+		if !found || len(reportDateAggregationRes.Buckets) <= 0 {
+			continue
+		}
+
+		topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+		if !found {
+			continue
+		}
+
+		results = append(results, topHitsAggregationRes.Hits.Hits...)
+	}
+
+	return results, nil
 }

--- a/tagging/ec2/es.go
+++ b/tagging/ec2/es.go
@@ -50,21 +50,33 @@ func queryEs(ctx context.Context, indexName string) (*elastic.SearchResult, erro
 	index := client.Search().Index(indexName)
 	filter := elastic.NewBoolQuery().Must(elastic.NewTermQuery("reportType", "daily"))
 	return index.Size(0).Query(filter).
-		Aggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
-			SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
-				Include("account", "instance.id", "instance.region", "instance.tags")))).Do(ctx)
+		Aggregation("accounts", elastic.NewTermsAggregation().Field("account").Size(2147483647).
+			SubAggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
+				SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
+					Include("account", "instance.id", "instance.region", "instance.tags"))))).Do(ctx)
 }
 
 func processSearchResult(res *elastic.SearchResult) ([]*elastic.SearchHit, error) {
-	reportDateAggregationRes, found := res.Aggregations.Terms("reportDate")
-	if !found || len(reportDateAggregationRes.Buckets) <= 0 {
-		return nil, errors.New("could not query elastic search")
-	}
-
-	topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+	accountAggregationRes, found := res.Aggregations.Terms("accounts")
 	if !found {
 		return nil, errors.New("could not query elastic search")
 	}
 
-	return topHitsAggregationRes.Hits.Hits, nil
+	results := []*elastic.SearchHit{}
+
+	for _, accountBucket := range accountAggregationRes.Buckets {
+		reportDateAggregationRes, found := accountBucket.Aggregations.Terms("reportDate")
+		if !found || len(reportDateAggregationRes.Buckets) <= 0 {
+			continue
+		}
+
+		topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+		if !found {
+			continue
+		}
+
+		results = append(results, topHitsAggregationRes.Hits.Hits...)
+	}
+
+	return results, nil
 }

--- a/tagging/elasticache/es.go
+++ b/tagging/elasticache/es.go
@@ -50,21 +50,33 @@ func queryEs(ctx context.Context, indexName string) (*elastic.SearchResult, erro
 	index := client.Search().Index(indexName)
 	filter := elastic.NewBoolQuery().Must(elastic.NewTermQuery("reportType", "daily"))
 	return index.Size(0).Query(filter).
-		Aggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
-			SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
-				Include("account", "instance.id", "instance.region", "instance.tags")))).Do(ctx)
+		Aggregation("accounts", elastic.NewTermsAggregation().Field("account").Size(2147483647).
+			SubAggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
+				SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
+					Include("account", "instance.id", "instance.region", "instance.tags"))))).Do(ctx)
 }
 
 func processSearchResult(res *elastic.SearchResult) ([]*elastic.SearchHit, error) {
-	reportDateAggregationRes, found := res.Aggregations.Terms("reportDate")
-	if !found || len(reportDateAggregationRes.Buckets) <= 0 {
-		return nil, errors.New("could not query elastic search")
-	}
-
-	topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+	accountAggregationRes, found := res.Aggregations.Terms("accounts")
 	if !found {
 		return nil, errors.New("could not query elastic search")
 	}
 
-	return topHitsAggregationRes.Hits.Hits, nil
+	results := []*elastic.SearchHit{}
+
+	for _, accountBucket := range accountAggregationRes.Buckets {
+		reportDateAggregationRes, found := accountBucket.Aggregations.Terms("reportDate")
+		if !found || len(reportDateAggregationRes.Buckets) <= 0 {
+			continue
+		}
+
+		topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+		if !found {
+			continue
+		}
+
+		results = append(results, topHitsAggregationRes.Hits.Hits...)
+	}
+
+	return results, nil
 }

--- a/tagging/es/es.go
+++ b/tagging/es/es.go
@@ -50,21 +50,33 @@ func queryEs(ctx context.Context, indexName string) (*elastic.SearchResult, erro
 	index := client.Search().Index(indexName)
 	filter := elastic.NewBoolQuery().Must(elastic.NewTermQuery("reportType", "daily"))
 	return index.Size(0).Query(filter).
-		Aggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
-			SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
-				Include("account", "domain.domainId", "domain.region", "domain.tags")))).Do(ctx)
+		Aggregation("accounts", elastic.NewTermsAggregation().Field("account").Size(2147483647).
+			SubAggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
+				SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
+					Include("account", "domain.domainId", "domain.region", "domain.tags"))))).Do(ctx)
 }
 
 func processSearchResult(res *elastic.SearchResult) ([]*elastic.SearchHit, error) {
-	reportDateAggregationRes, found := res.Aggregations.Terms("reportDate")
-	if !found || len(reportDateAggregationRes.Buckets) <= 0 {
-		return nil, errors.New("could not query elastic search")
-	}
-
-	topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+	accountAggregationRes, found := res.Aggregations.Terms("accounts")
 	if !found {
 		return nil, errors.New("could not query elastic search")
 	}
 
-	return topHitsAggregationRes.Hits.Hits, nil
+	results := []*elastic.SearchHit{}
+
+	for _, accountBucket := range accountAggregationRes.Buckets {
+		reportDateAggregationRes, found := accountBucket.Aggregations.Terms("reportDate")
+		if !found || len(reportDateAggregationRes.Buckets) <= 0 {
+			continue
+		}
+
+		topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+		if !found {
+			continue
+		}
+
+		results = append(results, topHitsAggregationRes.Hits.Hits...)
+	}
+
+	return results, nil
 }

--- a/tagging/lambda/es.go
+++ b/tagging/lambda/es.go
@@ -50,21 +50,33 @@ func queryEs(ctx context.Context, indexName string) (*elastic.SearchResult, erro
 	index := client.Search().Index(indexName)
 	filter := elastic.NewBoolQuery().Must(elastic.NewTermQuery("reportType", "daily"))
 	return index.Size(0).Query(filter).
-		Aggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
-			SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
-				Include("account", "function.name", "function.region", "function.tags")))).Do(ctx)
+		Aggregation("accounts", elastic.NewTermsAggregation().Field("account").Size(2147483647).
+			SubAggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
+				SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
+					Include("account", "function.name", "function.region", "function.tags"))))).Do(ctx)
 }
 
 func processSearchResult(res *elastic.SearchResult) ([]*elastic.SearchHit, error) {
-	reportDateAggregationRes, found := res.Aggregations.Terms("reportDate")
-	if !found || len(reportDateAggregationRes.Buckets) <= 0 {
-		return nil, errors.New("could not query elastic search")
-	}
-
-	topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+	accountAggregationRes, found := res.Aggregations.Terms("accounts")
 	if !found {
 		return nil, errors.New("could not query elastic search")
 	}
 
-	return topHitsAggregationRes.Hits.Hits, nil
+	results := []*elastic.SearchHit{}
+
+	for _, accountBucket := range accountAggregationRes.Buckets {
+		reportDateAggregationRes, found := accountBucket.Aggregations.Terms("reportDate")
+		if !found || len(reportDateAggregationRes.Buckets) <= 0 {
+			continue
+		}
+
+		topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+		if !found {
+			continue
+		}
+
+		results = append(results, topHitsAggregationRes.Hits.Hits...)
+	}
+
+	return results, nil
 }

--- a/tagging/rds/es.go
+++ b/tagging/rds/es.go
@@ -50,21 +50,33 @@ func queryEs(ctx context.Context, indexName string) (*elastic.SearchResult, erro
 	index := client.Search().Index(indexName)
 	filter := elastic.NewBoolQuery().Must(elastic.NewTermQuery("reportType", "daily"))
 	return index.Size(0).Query(filter).
-		Aggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
-			SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
-				Include("account", "instance.id", "instance.availabilityZone", "instance.tags")))).Do(ctx)
+		Aggregation("accounts", elastic.NewTermsAggregation().Field("account").Size(2147483647).
+			SubAggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
+				SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
+					Include("account", "instance.id", "instance.availabilityZone", "instance.tags"))))).Do(ctx)
 }
 
 func processSearchResult(res *elastic.SearchResult) ([]*elastic.SearchHit, error) {
-	reportDateAggregationRes, found := res.Aggregations.Terms("reportDate")
-	if !found || len(reportDateAggregationRes.Buckets) <= 0 {
-		return nil, errors.New("could not query elastic search")
-	}
-
-	topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+	accountAggregationRes, found := res.Aggregations.Terms("accounts")
 	if !found {
 		return nil, errors.New("could not query elastic search")
 	}
 
-	return topHitsAggregationRes.Hits.Hits, nil
+	results := []*elastic.SearchHit{}
+
+	for _, accountBucket := range accountAggregationRes.Buckets {
+		reportDateAggregationRes, found := accountBucket.Aggregations.Terms("reportDate")
+		if !found || len(reportDateAggregationRes.Buckets) <= 0 {
+			continue
+		}
+
+		topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+		if !found {
+			continue
+		}
+
+		results = append(results, topHitsAggregationRes.Hits.Hits...)
+	}
+
+	return results, nil
 }

--- a/tagging/rdsRi/es.go
+++ b/tagging/rdsRi/es.go
@@ -50,21 +50,33 @@ func queryEs(ctx context.Context, indexName string) (*elastic.SearchResult, erro
 	index := client.Search().Index(indexName)
 	filter := elastic.NewBoolQuery().Must(elastic.NewTermQuery("reportType", "daily"))
 	return index.Size(0).Query(filter).
-		Aggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
-			SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
-				Include("account", "instance.id", "instance.availabilityZone", "instance.tags")))).Do(ctx)
+		Aggregation("accounts", elastic.NewTermsAggregation().Field("account").Size(2147483647).
+			SubAggregation("reportDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
+				SubAggregation("data", elastic.NewTopHitsAggregation().Size(2147483647).FetchSourceContext(elastic.NewFetchSourceContext(true).
+					Include("account", "instance.id", "instance.availabilityZone", "instance.tags"))))).Do(ctx)
 }
 
 func processSearchResult(res *elastic.SearchResult) ([]*elastic.SearchHit, error) {
-	reportDateAggregationRes, found := res.Aggregations.Terms("reportDate")
-	if !found || len(reportDateAggregationRes.Buckets) <= 0 {
-		return nil, errors.New("could not query elastic search")
-	}
-
-	topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+	accountAggregationRes, found := res.Aggregations.Terms("accounts")
 	if !found {
 		return nil, errors.New("could not query elastic search")
 	}
 
-	return topHitsAggregationRes.Hits.Hits, nil
+	results := []*elastic.SearchHit{}
+
+	for _, accountBucket := range accountAggregationRes.Buckets {
+		reportDateAggregationRes, found := accountBucket.Aggregations.Terms("reportDate")
+		if !found || len(reportDateAggregationRes.Buckets) <= 0 {
+			continue
+		}
+
+		topHitsAggregationRes, found := reportDateAggregationRes.Buckets[0].Aggregations.TopHits("data")
+		if !found {
+			continue
+		}
+
+		results = append(results, topHitsAggregationRes.Hits.Hits...)
+	}
+
+	return results, nil
 }


### PR DESCRIPTION
This branch fixes the fact that when generating a tagging report, only the last AWS account of a TrackIt user was used because usage reports had different report dates.