### PR TITLE
Fixed regex to ignore aws:* in most used tags

### DIFF
--- a/tagging/updateMostUsedTags.go
+++ b/tagging/updateMostUsedTags.go
@@ -30,7 +30,7 @@ import (
 )
 
 var ignoredTagsRegexp = []string{
-	"aws:*",
+	"aws:.*",
 	"lambda:.*",
 	".*k8s\\.io.*",
 	"KubernetesCluster",


### PR DESCRIPTION
Fixed regex to ignore aws:* in most used tags