### PR TITLE
Added tagging suggestions route

### DIFF
--- a/tagging/routes/routeGetTaggingSuggestions.go
+++ b/tagging/routes/routeGetTaggingSuggestions.go
@@ -1,0 +1,89 @@
+//   Copyright 2020 MSolution.IO
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package routes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/olivere/elastic"
+
+	"github.com/trackit/trackit/es"
+	"github.com/trackit/trackit/routes"
+	"github.com/trackit/trackit/tagging"
+	"github.com/trackit/trackit/users"
+)
+
+const maxSuggestionsCount = 3
+
+func routeGetTaggingSuggestions(r *http.Request, a routes.Arguments) (int, interface{}) {
+	u := a[users.AuthenticatedUser].(users.User)
+	tagName := a[suggestionsQueryArgs[0]].(string)
+
+	suggestions, err := getSuggestions(r.Context(), u.Id, tagName)
+	if err != nil {
+		return http.StatusInternalServerError, nil
+	}
+
+	return http.StatusOK, map[string]interface{}{
+		"tagName":     tagName,
+		"suggestions": suggestions,
+	}
+}
+
+func getSuggestions(ctx context.Context, userId int, tagName string) ([]string, error) {
+	client := es.Client
+
+	res, err := client.Search().Index(es.IndexNameForUserId(userId, tagging.IndexPrefixTaggingReport)).Size(0).
+		Aggregation("byDate", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
+			SubAggregation("nested", elastic.NewNestedAggregation().Path("tags").
+				SubAggregation("byTagName", elastic.NewFilterAggregation().Filter(elastic.NewTermQuery("tags.key", "Name")).
+					SubAggregation("results", elastic.NewTermsAggregation().Field("tags.value").Size(maxSuggestionsCount))))).Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return processTaggingSuggestionsResult(res)
+}
+
+func processTaggingSuggestionsResult(res *elastic.SearchResult) ([]string, error) {
+	byDateRes, found := res.Aggregations.Terms("byDate")
+	if !found || len(byDateRes.Buckets) <= 0 {
+		return []string{}, nil
+	}
+
+	nestedRes, found := byDateRes.Buckets[0].Nested("nested")
+	if !found {
+		return []string{}, nil
+	}
+
+	byTagNameRes, found := nestedRes.Aggregations.Terms("byTagName")
+	if !found || len(byDateRes.Buckets) <= 0 {
+		return []string{}, nil
+	}
+
+	resultsRes, found := byTagNameRes.Aggregations.Terms("results")
+	if !found {
+		return []string{}, nil
+	}
+
+	results := []string{}
+
+	for _, buck := range resultsRes.Buckets {
+		results = append(results, fmt.Sprintf("%s", buck.Key))
+	}
+
+	return results, nil
+}

--- a/tagging/routes/routes.go
+++ b/tagging/routes/routes.go
@@ -48,9 +48,9 @@ var resourcesQueryArgs = []routes.QueryArg{
 // suggestionsQueryArgs allows to get required queryArgs params
 var suggestionsQueryArgs = []routes.QueryArg{
 	routes.QueryArg{
-		Name:        "tagName",
+		Name:        "tagkey",
 		Type:        routes.QueryArgString{},
-		Description: "Tag name for suggestions",
+		Description: "Tag key for suggestions",
 		Optional:    false,
 	},
 }
@@ -107,5 +107,5 @@ func init() {
 				Description: "Responds with suggestions for a tag's value for a user.",
 			},
 		),
-	}.H().Register("/tagging/suggestions")
+	}.H().Register("/tagging/suggestions/tag-value")
 }

--- a/tagging/routes/routes.go
+++ b/tagging/routes/routes.go
@@ -45,6 +45,16 @@ var resourcesQueryArgs = []routes.QueryArg{
 	},
 }
 
+// suggestionsQueryArgs allows to get required queryArgs params
+var suggestionsQueryArgs = []routes.QueryArg{
+	routes.QueryArg{
+		Name:        "tagName",
+		Type:        routes.QueryArgString{},
+		Description: "Tag name for suggestions",
+		Optional:    false,
+	},
+}
+
 func init() {
 	routes.MethodMuxer{
 		http.MethodGet: routes.H(routeGetMostUsedTags).With(
@@ -52,7 +62,7 @@ func init() {
 			users.RequireAuthenticatedUser{users.ViewerAsParent},
 			routes.Documentation{
 				Summary:     "get most used tags",
-				Description: "Responds with most used tags for an AWS account.",
+				Description: "Responds with most used tags for a user.",
 			},
 		),
 	}.H().Register("/tagging/mostusedtags")
@@ -84,4 +94,18 @@ func init() {
 			},
 		),
 	}.H().Register("/tagging/resources")
+}
+
+func init() {
+	routes.MethodMuxer{
+		http.MethodGet: routes.H(routeGetTaggingSuggestions).With(
+			db.RequestTransaction{db.Db},
+			users.RequireAuthenticatedUser{users.ViewerAsParent},
+			routes.QueryArgs(suggestionsQueryArgs),
+			routes.Documentation{
+				Summary:     "get suggestions for a tag's value",
+				Description: "Responds with suggestions for a tag's value for a user.",
+			},
+		),
+	}.H().Register("/tagging/suggestions")
 }


### PR DESCRIPTION
This Pr adds the route to get 3 suggestions of values for a tag key passed in query's arguments.

Suggestions are based on the 3 most used values for the key