### PR TITLE
Changed tagging resources route

### DIFF
--- a/tagging/routes/esRequestConstructor.go
+++ b/tagging/routes/esRequestConstructor.go
@@ -50,7 +50,7 @@ func getElasticSeachResourcesParams(params ResourcesRequestBody, client *elastic
 	}
 	search := client.Search().Index(index).Size(0).Query(query)
 	search.Aggregation("accounts", elastic.NewTermsAggregation().Field("account").
-		SubAggregation("dates", elastic.NewTermsAggregation().Field("reportDate").
+		SubAggregation("dates", elastic.NewTermsAggregation().Field("reportDate").Order("_term", false).Size(1).
 			SubAggregation("resources", elastic.NewTopHitsAggregation().Sort("reportDate", false).Size(maxAggregationSize))))
 	return search
 }

--- a/tagging/routes/esRequestConstructor.go
+++ b/tagging/routes/esRequestConstructor.go
@@ -22,7 +22,7 @@ const maxAggregationSize = 0x7FFFFFFF
 
 // getElasticSearchResourcesParams is used to construct an ElasticSearch *elastic.SearchService used to perform a request on ES
 // It takes as parameters :
-// 	- params ResourcesQueryParams : contains the list of accounts
+// 	- params ResourcesRequestBody : contains the list of accounts and filters
 //	- client *elastic.Client : an instance of *elastic.Client that represent an Elastic Search client.
 //	It needs to be fully configured and ready to execute a client.Search()
 //	- index string : The Elastic Search index on which to execute the query. In this context the default value
@@ -31,16 +31,22 @@ const maxAggregationSize = 0x7FFFFFFF
 // it crash :
 //	- If the client is nil or malconfigured, it will crash
 //	- If the index is not an index present in the ES, it will crash
-func getElasticSeachResourcesParams(params ResourcesQueryParams, client *elastic.Client, index string) *elastic.SearchService {
+func getElasticSeachResourcesParams(params ResourcesRequestBody, client *elastic.Client, index string) *elastic.SearchService {
 	query := elastic.NewBoolQuery()
-	if len(params.AccountsList) > 0 {
-		query = query.Filter(createQueryAccountFilterResources(params.AccountsList))
+	if len(params.Accounts) > 0 {
+		query = query.Filter(createQueryAccountFilterResources(params.Accounts))
 	}
 	if len(params.Regions) > 0 {
 		query = query.Filter(createQueryRegionFilterResources(params.Regions))
 	}
 	if len(params.ResourceTypes) > 0 {
 		query = query.Filter(createQueryTypeFilterResources(params.ResourceTypes))
+	}
+	if len(params.Tags) > 0 {
+		query = query.Filter(createQueryTagsFilterResources(params.Tags))
+	}
+	if len(params.MissingTags) > 0 {
+		query = query.Filter(createQueryMissingTagsFilterResources(params.MissingTags))
 	}
 	search := client.Search().Index(index).Size(0).Query(query)
 	search.Aggregation("accounts", elastic.NewTermsAggregation().Field("account").
@@ -67,11 +73,29 @@ func createQueryRegionFilterResources(regionList []string) *elastic.TermsQuery {
 	return elastic.NewTermsQuery("region", regionListFormatted...)
 }
 
-//createQueryTypeFilterResources creates and return a nex *elastic.TermsQuery on the typeList array
+//createQueryTypeFilterResources creates and return a new *elastic.TermsQuery on the typeList array
 func createQueryTypeFilterResources(typeList []string) *elastic.TermsQuery {
 	typeListFormatted := make([]interface{}, len(typeList))
 	for i, v := range typeList {
 		typeListFormatted[i] = v
 	}
 	return elastic.NewTermsQuery("resourceType", typeListFormatted...)
+}
+
+//createQueryTagsFilterResources creates and return a new *elastic.BoolQuery based on the tagList
+func createQueryTagsFilterResources(tagList []Tag) *elastic.BoolQuery {
+	termQueries := []elastic.Query{}
+	for _, v := range tagList {
+		termQueries = append(termQueries, elastic.NewNestedQuery("tags", elastic.NewBoolQuery().Must(elastic.NewTermQuery("tags.key", v.Key), elastic.NewTermQuery("tags.value", v.Value))))
+	}
+	return elastic.NewBoolQuery().Must(termQueries...)
+}
+
+//createQueryTypeFilterResources creates and return a new *elastic.BoolQuery based on the missingTagList
+func createQueryMissingTagsFilterResources(missingTagList []Tag) *elastic.BoolQuery {
+	termQueries := []elastic.Query{}
+	for _, v := range missingTagList {
+		termQueries = append(termQueries, elastic.NewNestedQuery("tags", elastic.NewBoolQuery().Must(elastic.NewTermQuery("tags.key", v.Key), elastic.NewTermQuery("tags.value", v.Value))))
+	}
+	return elastic.NewBoolQuery().MustNot(termQueries...)
 }

--- a/tagging/routes/routeGetResources.go
+++ b/tagging/routes/routeGetResources.go
@@ -81,30 +81,30 @@ func GetResources(ctx context.Context, params ResourcesRequestBody, user users.U
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, params ResourcesRequestBody, user users.User,
 	esSearchParams func(ResourcesRequestBody, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {
-		l := jsonlog.LoggerFromContextOrDefault(ctx)
-		index := es.IndexNameForUser(user, tagging.IndexPrefixTaggingReport)
-		searchService := esSearchParams(
-			params,
-			es.Client,
-			index,
-		)
-		res, err := searchService.Do(ctx)
-		if err != nil {
-			if elastic.IsNotFound(err) {
-				l.Warning("Query execution failed, ES index does not exists", map[string]interface{}{
-					"index": index,
-					"error": err.Error(),
-				})
-				return nil, http.StatusOK, terrors.GetErrorMessage(ctx, err)
-			} else if cast, ok := err.(*elastic.Error); ok && cast.Details != nil && cast.Details.Type == "search_phase_execution_exception" {
-				l.Error("Error while getting data from ES", map[string]interface{}{
-					"type":  fmt.Sprintf("%T", err),
-					"error": err,
-				})
-			} else {
-				l.Error("Query execution failed", map[string]interface{}{"error": err.Error()})
-			}
-			return nil, http.StatusInternalServerError, terrors.GetErrorMessage(ctx, err)
+	l := jsonlog.LoggerFromContextOrDefault(ctx)
+	index := es.IndexNameForUser(user, tagging.IndexPrefixTaggingReport)
+	searchService := esSearchParams(
+		params,
+		es.Client,
+		index,
+	)
+	res, err := searchService.Do(ctx)
+	if err != nil {
+		if elastic.IsNotFound(err) {
+			l.Warning("Query execution failed, ES index does not exists", map[string]interface{}{
+				"index": index,
+				"error": err.Error(),
+			})
+			return nil, http.StatusOK, terrors.GetErrorMessage(ctx, err)
+		} else if cast, ok := err.(*elastic.Error); ok && cast.Details != nil && cast.Details.Type == "search_phase_execution_exception" {
+			l.Error("Error while getting data from ES", map[string]interface{}{
+				"type":  fmt.Sprintf("%T", err),
+				"error": err,
+			})
+		} else {
+			l.Error("Query execution failed", map[string]interface{}{"error": err.Error()})
 		}
-		return res, http.StatusOK, nil
+		return nil, http.StatusInternalServerError, terrors.GetErrorMessage(ctx, err)
+	}
+	return res, http.StatusOK, nil
 }

--- a/tagging/routes/routeGetResources.go
+++ b/tagging/routes/routeGetResources.go
@@ -16,16 +16,13 @@ package routes
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
 
-	"github.com/trackit/trackit/db"
 	"github.com/trackit/trackit/routes"
 	"github.com/trackit/trackit/users"
 	terrors "github.com/trackit/trackit/errors"
@@ -34,35 +31,25 @@ import (
 	"github.com/trackit/trackit/tagging"
 )
 
-type (
-	// ResourcesQueryParams will store the parsed query params
-	ResourcesQueryParams struct {
-		AccountsList   []string
-		IndexesList    []string
-		Regions        []string
-		ResourceTypes  []string
-	}
-)
+type Tag struct {
+	Key   string `json:"key"   req:"nonzero"`
+	Value string `json:"value" req:"nonzero"`
+}
 
-// routeGetResources returns the list of resources based on the query params, in JSON format.
+type ResourcesRequestBody struct {
+	Accounts      []string `json:"accounts"      req:"nonzero"`
+	Regions       []string `json:"regions"       req:"nonzero"`
+	ResourceTypes []string `json:"resourceTypes" req:"nonzero"`
+	Tags          []Tag    `json:"tags"          req:"nonzero"`
+	MissingTags   []Tag    `json:"missingTags"   req:"nonzero"`
+}
+
+// routeGetResources returns the list of resources based on the request body, in JSON format.
 func routeGetResources(request *http.Request, a routes.Arguments) (int, interface{}) {
+	var body ResourcesRequestBody
+	routes.MustRequestBody(a, &body)
 	user := a[users.AuthenticatedUser].(users.User)
-	tx := a[db.Transaction].(*sql.Tx)
-	parsedParams := ResourcesQueryParams{
-		AccountsList:  []string{},
-		Regions:       []string{},
-		ResourceTypes: []string{},
-	}
-	if a[routes.AwsAccountsOptionalQueryArg] != nil {
-		parsedParams.AccountsList = a[routes.AwsAccountsOptionalQueryArg].([]string)
-	}
-	if a[resourcesQueryArgs[1]] != nil {
-		parsedParams.Regions = a[resourcesQueryArgs[1]].([]string)
-	}
-	if a[resourcesQueryArgs[2]] != nil {
-		parsedParams.ResourceTypes = a[resourcesQueryArgs[2]].([]string)
-	}
-	returnCode, report, err := GetResourcesData(request.Context(), parsedParams, user, tx)
+	returnCode, report, err := GetResources(request.Context(), body, user)
 	if err != nil {
 		return returnCode, err
 	} else {
@@ -70,24 +57,9 @@ func routeGetResources(request *http.Request, a routes.Arguments) (int, interfac
 	}
 }
 
-// GetResourcesData gets resources report based on query params
-func GetResourcesData(ctx context.Context, parsedParams ResourcesQueryParams, user users.User, tx *sql.Tx) (int, []utils.TaggingReportDocument, error) {
-	accountsAndIndexes, returnCode, err := es.GetAccountsAndIndexes(parsedParams.AccountsList, user, tx, tagging.IndexPrefixTaggingReport)
-	if err != nil {
-		return returnCode, nil, err
-	}
-	parsedParams.AccountsList = accountsAndIndexes.Accounts
-	parsedParams.IndexesList = accountsAndIndexes.Indexes
-	returnCode, resources, err := GetResources(ctx, parsedParams)
-	if err != nil {
-		return returnCode, nil, err
-	}
-	return returnCode, resources, nil
-}
-
-// GetResources does an elastic request and returns an array of resources report based on query params
-func GetResources(ctx context.Context, params ResourcesQueryParams) (int, []utils.TaggingReportDocument, error) {
-	res, returnCode, err := makeElasticSearchRequest(ctx, params, getElasticSeachResourcesParams)
+// GetResources does an elastic request and returns an array of resources report based on the request body
+func GetResources(ctx context.Context, params ResourcesRequestBody, user users.User) (int, []utils.TaggingReportDocument, error) {
+	res, returnCode, err := makeElasticSearchRequest(ctx, params, user, getElasticSeachResourcesParams)
 	if err != nil {
 		return returnCode, nil, err
 	} else if res == nil {
@@ -101,38 +73,38 @@ func GetResources(ctx context.Context, params ResourcesQueryParams) (int, []util
 }
 
 // makeElasticSearchRequest prepares and run an ES request
-// based on the ResourcesQueryParams and search params
+// based on the ResourcesRequestBody and search params
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
 // be returned, but instead of having a 500 status code, it will return the provided status code
 // with empty data
-func makeElasticSearchRequest(ctx context.Context, parsedParams ResourcesQueryParams,
-	esSearchParams func(ResourcesQueryParams, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {
-	l := jsonlog.LoggerFromContextOrDefault(ctx)
-	index := strings.Join(parsedParams.IndexesList, ",")
-	searchService := esSearchParams(
-		parsedParams,
-		es.Client,
-		index,
-	)
-	res, err := searchService.Do(ctx)
-	if err != nil {
-		if elastic.IsNotFound(err) {
-			l.Warning("Query execution failed, ES index does not exists", map[string]interface{}{
-				"index": index,
-				"error": err.Error(),
-			})
-			return nil, http.StatusOK, terrors.GetErrorMessage(ctx, err)
-		} else if cast, ok := err.(*elastic.Error); ok && cast.Details != nil && cast.Details.Type == "search_phase_execution_exception" {
-			l.Error("Error while getting data from ES", map[string]interface{}{
-				"type":  fmt.Sprintf("%T", err),
-				"error": err,
-			})
-		} else {
-			l.Error("Query execution failed", map[string]interface{}{"error": err.Error()})
+func makeElasticSearchRequest(ctx context.Context, params ResourcesRequestBody, user users.User,
+	esSearchParams func(ResourcesRequestBody, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {
+		l := jsonlog.LoggerFromContextOrDefault(ctx)
+		index := es.IndexNameForUser(user, tagging.IndexPrefixTaggingReport)
+		searchService := esSearchParams(
+			params,
+			es.Client,
+			index,
+		)
+		res, err := searchService.Do(ctx)
+		if err != nil {
+			if elastic.IsNotFound(err) {
+				l.Warning("Query execution failed, ES index does not exists", map[string]interface{}{
+					"index": index,
+					"error": err.Error(),
+				})
+				return nil, http.StatusOK, terrors.GetErrorMessage(ctx, err)
+			} else if cast, ok := err.(*elastic.Error); ok && cast.Details != nil && cast.Details.Type == "search_phase_execution_exception" {
+				l.Error("Error while getting data from ES", map[string]interface{}{
+					"type":  fmt.Sprintf("%T", err),
+					"error": err,
+				})
+			} else {
+				l.Error("Query execution failed", map[string]interface{}{"error": err.Error()})
+			}
+			return nil, http.StatusInternalServerError, terrors.GetErrorMessage(ctx, err)
 		}
-		return nil, http.StatusInternalServerError, terrors.GetErrorMessage(ctx, err)
-	}
-	return res, http.StatusOK, nil
+		return res, http.StatusOK, nil
 }

--- a/tagging/routes/routes.go
+++ b/tagging/routes/routes.go
@@ -28,23 +28,6 @@ var taggingComplianceQueryArgs = []routes.QueryArg{
 	routes.DateEndQueryArg,
 }
 
-// resourcesQueryArgs allows to get required queryArgs params
-var resourcesQueryArgs = []routes.QueryArg{
-	routes.AwsAccountsOptionalQueryArg,
-	routes.QueryArg{
-		Name:        "regions",
-		Type:        routes.QueryArgStringSlice{},
-		Description: "Regions of the resources",
-		Optional:    true,
-	},
-	routes.QueryArg{
-		Name:        "resourceTypes",
-		Type:        routes.QueryArgStringSlice{},
-		Description: "Types of the resources",
-		Optional:    true,
-	},
-}
-
 // suggestionsQueryArgs allows to get required queryArgs params
 var suggestionsQueryArgs = []routes.QueryArg{
 	routes.QueryArg{
@@ -84,13 +67,14 @@ func init() {
 
 func init() {
 	routes.MethodMuxer{
-		http.MethodGet: routes.H(routeGetResources).With(
+		http.MethodPost: routes.H(routeGetResources).With(
 			db.RequestTransaction{db.Db},
 			users.RequireAuthenticatedUser{users.ViewerAsParent},
-			routes.QueryArgs(resourcesQueryArgs),
+			routes.RequestContentType{"application/json"},
+			routes.RequestBody{ResourcesRequestBody{[]string{"394125495069"}, []string{"us-west-2"}, []string{"lambda"}, []Tag{{"project", "trackit"}}, []Tag{{"Product", "msol"}}}},
 			routes.Documentation{
 				Summary:     "get list of resources",
-				Description: "Responds with the list of resources based on the queryparams passed to it",
+				Description: "Responds with the list of resources based on the request body passed to it",
 			},
 		),
 	}.H().Register("/tagging/resources")


### PR DESCRIPTION
This PR changes the route to get resources.
Now using a POST Method instead of a GET Method.
The filter that allows to retrieve resources based on tags and missing tags is now implemented.