### PR TITLE
Fixed error because AWS marketplace entitlement is false in JWT token

### DIFF
--- a/users/auth.go
+++ b/users/auth.go
@@ -99,9 +99,6 @@ func testToken(tx *sql.Tx, tokenString string) (User, error) {
 			if areClaimsValid(*claims) {
 				userId := claims.Subject
 				user, err = GetUserWithId(tx, userId)
-				if !user.AwsCustomerEntitlement {
-					err = ErrMarketplaceInvalidToken
-				}
 			} else {
 				err = ErrInvalidClaims
 			}


### PR DESCRIPTION
We don't want users without AWS marketplace to be unable to do requests.
It was working before but since now AWS marketplace entitlements checks works, it causes problems.