### PR TITLE
Exclude AWSDataTransfer product from /costs route

### DIFF
--- a/costs/es_request_constructor.go
+++ b/costs/es_request_constructor.go
@@ -265,14 +265,14 @@ func nestAggregation(allAggrSlice []paramAggrAndName) elastic.Aggregation {
 //	- If a param in the slice is not present in the detailedLineItemsFieldsName, the program will crash.
 //	- If the client is nil or malconfigured, it will crash
 //	- If the index is not an index present in the ES, it will crash
+// We are excluding AWSDataTransfer products because it's value is always zero.
+// Data transfer costs are included in other products' costs.
 func GetElasticSearchParams(accountList []string, durationBegin time.Time,
 	durationEnd time.Time, params []string, client *elastic.Client, index string) *elastic.SearchService {
 	query := elastic.NewBoolQuery()
 	if len(accountList) > 0 {
 		query = query.Filter(createQueryAccountFilter(accountList))
 	}
-	// We are excluding AWSDataTransfer products because it's value is always zero.
-	// Data transfer costs are included in other products' costs.
 	query = query.Filter(createQueryTimeRange(durationBegin, durationEnd),
 		elastic.NewBoolQuery().MustNot(elastic.NewTermQuery("productCode", "AWSDataTransfer")))
 	search := client.Search().Index(index).Size(0).Query(query)

--- a/costs/es_request_constructor.go
+++ b/costs/es_request_constructor.go
@@ -271,7 +271,8 @@ func GetElasticSearchParams(accountList []string, durationBegin time.Time,
 	if len(accountList) > 0 {
 		query = query.Filter(createQueryAccountFilter(accountList))
 	}
-	query = query.Filter(createQueryTimeRange(durationBegin, durationEnd))
+	query = query.Filter(createQueryTimeRange(durationBegin, durationEnd),
+		elastic.NewBoolQuery().MustNot(elastic.NewTermQuery("productCode", "AWSDataTransfer")))
 	search := client.Search().Index(index).Size(0).Query(query)
 	params = append(params, "cost")
 	var allAggregationSlice []paramAggrAndName

--- a/costs/es_request_constructor.go
+++ b/costs/es_request_constructor.go
@@ -271,6 +271,8 @@ func GetElasticSearchParams(accountList []string, durationBegin time.Time,
 	if len(accountList) > 0 {
 		query = query.Filter(createQueryAccountFilter(accountList))
 	}
+	// We are excluding AWSDataTransfer products because it's value is always zero.
+	// Data transfer costs are included in other products' costs.
 	query = query.Filter(createQueryTimeRange(durationBegin, durationEnd),
 		elastic.NewBoolQuery().MustNot(elastic.NewTermQuery("productCode", "AWSDataTransfer")))
 	search := client.Search().Index(index).Size(0).Query(query)


### PR DESCRIPTION
This PR excludes `AWSDataTransfer` product in the `/costs` route.
This is because this product code is only used for taxes and the value is always 0.

Data transfer costs are actually included in other product codes: for example EC2 instances data transfer costs have a `productCode` = `AmazonEC2` and a `serviceCode` = `AWSDataTransfer`.