### PR TITLE
Fixed file ulimit-related failure at runtime in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
       - app
     ports:
       - '127.0.0.1:9200:9200'
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
   redis:
     image: redis:latest
     command: ["redis-server", "--requirepass changeme"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,10 @@ services:
       - app
     ports:
       - '127.0.0.1:9200:9200'
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
   redis:
     image: redis:latest
     command: ["redis-server", "--requirepass changeme"]


### PR DESCRIPTION
On a system where the soft `ulimit -n` (maximum amount of open files) is less than 65536, there would be problems starting up the API under docker without this fix