### PR TITLE
Fix a bunch of context leaks

### DIFF
--- a/anomaliesDetection/mappings.go
+++ b/anomaliesDetection/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameAnomaliesDetection = "anomalies-detection"
 // put the ElasticSearch index for *-anomalies-detection indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameAnomaliesDetection).BodyString(TemplateAnomaliesDetection).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index AnomaliesDetection.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index AnomaliesDetection.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/s3/mappings.go
+++ b/aws/s3/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameLineItem = "lineitems"
 // put the ElasticSearch index for *-lineitems indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameLineItem).BodyString(TemplateLineItem).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index lineitems.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index lineitems.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/cloudformation/mappings.go
+++ b/aws/usageReports/cloudformation/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameCloudFormationReport = "cloudformation-reports"
 // put the ElasticSearch index for *-cloudformation-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameCloudFormationReport).BodyString(TemplateCloudFormationReport).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index cloudformation-reports.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index cloudformation-reports.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/ebs/mappings.go
+++ b/aws/usageReports/ebs/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameEBSReport = "ebs-reports"
 // put the ElasticSearch index for *-ebs-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameEBSReport).BodyString(TemplateEbsReport).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index EBSReport.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index EBSReport.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/ec2/mappings.go
+++ b/aws/usageReports/ec2/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameEC2Report = "ec2-reports"
 // put the ElasticSearch index for *-ec2-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameEC2Report).BodyString(TemplateEc2Report).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index EC2Report.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index EC2Report.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/ec2Coverage/mappings.go
+++ b/aws/usageReports/ec2Coverage/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameEC2CoverageReport = "ec2-coverage-reports"
 // put the ElasticSearch index for *-ec2-coverage-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameEC2CoverageReport).BodyString(TemplateEc2CoverageReport).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index EC2 Coverage Report.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index EC2 Coverage Report.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/elasticache/mappings.go
+++ b/aws/usageReports/elasticache/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameElastiCacheReport = "elasticache-reports"
 // put the ElasticSearch index for *-elasticache-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameElastiCacheReport).BodyString(TemplateElastiCacheReport).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index ElastiCache Report.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index ElastiCache Report.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/es/mappings.go
+++ b/aws/usageReports/es/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameESReport = "es-reports"
 // put the ElasticSearch index for *-es-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameESReport).BodyString(TemplateEsReport).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index ESReport.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index ESReport.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/instanceCount/mappings.go
+++ b/aws/usageReports/instanceCount/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameInstanceCountReport = "instancecount-reports"
 // put the ElasticSearch index for *-instanceCount-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameInstanceCountReport).BodyString(TemplateInstanceCountReport).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index InstanceCountReport.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index InstanceCountReport.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/lambda/mappings.go
+++ b/aws/usageReports/lambda/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameLambdaReport = "lambda-reports"
 // put the ElasticSearch index for *-lambda-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameLambdaReport).BodyString(TemplateLineItem).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index LambdaReport.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index LambdaReport.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/rds/mappings.go
+++ b/aws/usageReports/rds/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameRDSReport = "rds-reports"
 // put the ElasticSearch index for *-rds-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameRDSReport).BodyString(TemplateRdsReport).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index rds-reports.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index rds-reports.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/riEc2/mappings.go
+++ b/aws/usageReports/riEc2/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameReservedInstancesReport = "ri-ec2-reports"
 // put the ElasticSearch index for *-ri-ec2-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameReservedInstancesReport).BodyString(TemplateLineItem).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index ReservedInstancesReport.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index ReservedInstancesReport.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/riRdS/mappings.go
+++ b/aws/usageReports/riRdS/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameReservedRDSReport = "rds-ri-reports"
 // put the ElasticSearch index for *-rds-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameReservedRDSReport).BodyString(TemplateReservedRdsReport).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index rds-ri-reports.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index rds-ri-reports.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/route53/mappings.go
+++ b/aws/usageReports/route53/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameRoute53Report = "route53-reports"
 // put the ElasticSearch index for *-route53-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameRoute53Report).BodyString(TemplateRoute53Report).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index route53-reports.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index route53-reports.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/s3/mappings.go
+++ b/aws/usageReports/s3/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameS3Report = "s3-reports"
 // put the ElasticSearch index for *-s3-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameS3Report).BodyString(TemplateS3Report).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index s3-reports.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index s3-reports.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/sqs/mappings.go
+++ b/aws/usageReports/sqs/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameSQSReport = "sqs-reports"
 // put the ElasticSearch index for *-sqs-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameSQSReport).BodyString(TemplateSQSReport).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index sqs-reports.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index sqs-reports.", res)
-		ctxCancel()
 	}
 }
 

--- a/aws/usageReports/stepfunction/mappings.go
+++ b/aws/usageReports/stepfunction/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameStepFunctionReport = "stepfunction-reports"
 // put the ElasticSearch index for *-stepfunction-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameStepFunctionReport).BodyString(TemplateStepFunctionReport).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index stepfunction-reports.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index stepfunction-reports.", res)
-		ctxCancel()
 	}
 }
 

--- a/onDemandToRI/ec2/mappings.go
+++ b/onDemandToRI/ec2/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameOdToRiEC2Report = "od-to-ri-ec2-reports"
 // put the ElasticSearch index for *-od-to-ri-ec2-reports indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameOdToRiEC2Report).BodyString(TemplateOdToRiEc2Report).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index OdToRiEC2Report.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index OdToRiEC2Report.", res)
-		ctxCancel()
 	}
 }
 

--- a/plugins/account/core/mappings.go
+++ b/plugins/account/core/mappings.go
@@ -30,12 +30,12 @@ const TemplateNameAccountPlugin = "account-plugins"
 // put the ElasticSearch index for *-account-plugins indices at startup.
 func init() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
 	res, err := es.Client.IndexPutTemplate(TemplateNameAccountPlugin).BodyString(TemplateAccountPlugin).Do(ctx)
 	if err != nil {
 		jsonlog.DefaultLogger.Error("Failed to put ES index account-plugins.", err)
 	} else {
 		jsonlog.DefaultLogger.Info("Put ES index account-plugins.", res)
-		ctxCancel()
 	}
 }
 


### PR DESCRIPTION
Context leaks are very frequent because of one copy-pasted code template that only executes the context cancel function when there is no error (meaning there is a leak, however temporary because of the WithTimeout usage, whenever an error occurs). There is also one other leak of this kind which would always occur, in `aws/s3/readBills.go`, which also has been fixed.