### PR TITLE
Fix bad json field tags

### DIFF
--- a/aws/routes/routeAwsPost.go
+++ b/aws/routes/routeAwsPost.go
@@ -114,18 +114,18 @@ func testAndCreateAwsAccount(ctx context.Context, tx *sql.Tx, account *aws.AwsAc
 // testAndCreateAwsAccountError is used to log errors in
 // testAndCreateAwsAccount.
 type testAndCreateAwsAccountError struct {
-	err     string         `json:"error"`
-	account aws.AwsAccount `json:"account"`
-	user    users.User     `json:"user"`
+	Err     string         `json:"error"`
+	Account aws.AwsAccount `json:"account"`
+	User    users.User     `json:"user"`
 }
 
 // newTestAndCreateAwsAccountError is used to log errors in
 // testAndCreateAwsAccount.
 func newTestAndCreateAwsAccountError(e error, a aws.AwsAccount, u users.User) testAndCreateAwsAccountError {
 	return testAndCreateAwsAccountError{
-		err:     e.Error(),
-		account: a,
-		user:    u,
+		Err:     e.Error(),
+		Account: a,
+		User:    u,
 	}
 }
 

--- a/aws/s3/readBills.go
+++ b/aws/s3/readBills.go
@@ -103,7 +103,7 @@ type LineItem struct {
 	UsageAccountId     string            `csv:"lineItem/UsageAccountId"      json:"usageAccountId"`
 	LineItemType       string            `csv:"lineItem/LineItemType"        json:"lineItemType"`
 	UsageStartDate     string            `csv:"lineItem/UsageStartDate"      json:"usageStartDate"`
-	UsageEndDate       string            `csv:"lineItem/UsageEndDate"        json:"usageEndDate""`
+	UsageEndDate       string            `csv:"lineItem/UsageEndDate"        json:"usageEndDate"`
 	ProductCode        string            `csv:"lineItem/ProductCode"         json:"productCode"`
 	UsageType          string            `csv:"lineItem/UsageType"           json:"usageType"`
 	Operation          string            `csv:"lineItem/Operation"           json:"operation"`

--- a/users/users.go
+++ b/users/users.go
@@ -40,7 +40,7 @@ type User struct {
 	Email                  string `json:"email"`
 	NextExternal           string `json:"-"`
 	ParentId               *int   `json:"parentId,omitempty"`
-	AwsCustomerEntitlement bool   `json:aws_customer_entitlement`
+	AwsCustomerEntitlement bool   `json:"aws_customer_entitlement"`
 }
 
 // CreateUserWithPassword creates a user with an email and a password. A nil


### PR DESCRIPTION
There were a few problems with the json field tags I've fixed here:

- Some were applied to unexported fields, i.e. the json package wouldn't see them
- Some had syntax errors, like lacking quotes around the tag name or having too many of them, which would sometimes result in the json package ignoring them and using the raw field name instead of the tag