### PR TITLE
Fix some bad format strings

### DIFF
--- a/plugins/account/networkEc2/networkEc2.go
+++ b/plugins/account/networkEc2/networkEc2.go
@@ -76,7 +76,7 @@ func processNetworkEc2(params core.PluginParams) (res core.PluginResult) {
 	tx, err := db.Db.Begin()
 	if err != nil {
 		res.Status = "red"
-		res.Error = fmt.Sprintln("Unable to retrieve EC2 instances : %s", err.Error())
+		res.Error = fmt.Sprintln("Unable to retrieve EC2 instances : ", err.Error())
 		return
 	}
 	_, instances, err := ec2.GetEc2Data(params.Context,
@@ -84,7 +84,7 @@ func processNetworkEc2(params core.PluginParams) (res core.PluginResult) {
 		params.User, tx)
 	if err != nil {
 		res.Status = "red"
-		res.Error = fmt.Sprintln("Unable to retrieve EC2 instances : %s", err.Error())
+		res.Error = fmt.Sprintln("Unable to retrieve EC2 instances : ", err.Error())
 		return
 	}
 	getUnusedEc2Recommendation(&res, instances)

--- a/plugins/account/s3Traffic/s3Traffic.go
+++ b/plugins/account/s3Traffic/s3Traffic.go
@@ -70,13 +70,13 @@ func processS3Traffic(pluginParams core.PluginParams, pluginRes *core.PluginResu
 	res, err := searchService.Do(pluginParams.Context)
 	if err != nil {
 		pluginRes.Status = "red"
-		pluginRes.Error = fmt.Sprintln("Unable to retrieve S3 storage usage : %s", err.Error())
+		pluginRes.Error = fmt.Sprintln("Unable to retrieve S3 storage usage : ", err.Error())
 		return
 	}
 	storage, err := parseESResult(pluginParams, res)
 	if err != nil {
 		pluginRes.Status = "red"
-		pluginRes.Error = fmt.Sprintln("Unable to parse S3 storage usage: %s", err.Error())
+		pluginRes.Error = fmt.Sprintln("Unable to parse S3 storage usage: ", err.Error())
 		return
 	}
 
@@ -84,13 +84,13 @@ func processS3Traffic(pluginParams core.PluginParams, pluginRes *core.PluginResu
 	res, err = searchService.Do(pluginParams.Context)
 	if err != nil {
 		pluginRes.Status = "red"
-		pluginRes.Error = fmt.Sprintln("Unable to retrieve S3 bandwidth usage : %s", err.Error())
+		pluginRes.Error = fmt.Sprintln("Unable to retrieve S3 bandwidth usage : ", err.Error())
 		return
 	}
 	bandwidth, err := parseESResult(pluginParams, res)
 	if err != nil {
 		pluginRes.Status = "red"
-		pluginRes.Error = fmt.Sprintln("Unable to parse S3 bandwidth usage: %s", err.Error())
+		pluginRes.Error = fmt.Sprintln("Unable to parse S3 bandwidth usage: ", err.Error())
 		return
 	}
 	getBucketsWithNoTraffic(pluginRes, storage, bandwidth)

--- a/users/create.go
+++ b/users/create.go
@@ -42,7 +42,7 @@ const (
 )
 
 var (
-	ErrPasswordTooShort = errors.New(fmt.Sprintf("Password must be at least %u characters.", passwordMaxLength))
+	ErrPasswordTooShort = errors.New(fmt.Sprintf("Password must be at least %v characters.", passwordMaxLength))
 )
 
 func init() {


### PR DESCRIPTION
Several fmt.Sprintln calls would use "%s" erroneously (fmt.Sprintln doesn't interpret format strings), which would result in an output containing a random %s in the middle after the ": ".

There was also one instance in which an fmt.Sprintf call used %u, which is not a valid verb in Go (%v should be used instead)