### PR TITLE
Fix a bunch of shadowing problems

### DIFF
--- a/anomaliesDetection/products.go
+++ b/anomaliesDetection/products.go
@@ -234,7 +234,7 @@ func productGetAnomaliesData(ctx context.Context, params AnomalyEsQueryParams) (
 		return nil, err
 	}
 	var typedDocument esProductTypedResult
-	if err := json.Unmarshal(*sr.Aggregations["products"], &typedDocument.Products); err != nil {
+	if err = json.Unmarshal(*sr.Aggregations["products"], &typedDocument.Products); err != nil {
 		logger.Error("Failed to parse elasticsearch document.", err.Error())
 		return nil, err
 	}
@@ -260,8 +260,5 @@ func productGetAnomaliesData(ctx context.Context, params AnomalyEsQueryParams) (
 		totalAnalyzedCosts = append(totalAnalyzedCosts, aCosts...)
 	}
 	totalAnalyzedCosts = productClearDisturbances(totalAnalyzedCosts, totalCostsByDay, highestSpendersByDay)
-	if err != nil {
-		return nil, err
-	}
 	return totalAnalyzedCosts, nil
 }

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -181,7 +181,7 @@ func (a *AwsAccount) UpdatePrettyAwsAccount(ctx context.Context, tx *sql.Tx) err
 		dbAwsAccount.Pretty = a.Pretty
 		dbAwsAccount.Payer = a.Payer
 		dbAwsAccount.RoleArn = a.RoleArn
-		err := dbAwsAccount.Update(tx)
+		err = dbAwsAccount.Update(tx)
 		if err != nil {
 			logger.Error("Failed to update AWS account in database.", err.Error())
 		}
@@ -223,7 +223,7 @@ func (a *AwsAccount) UpdateRoleAndExternalAwsAccount(ctx context.Context, tx *sq
 	} else {
 		dbAwsAccount.RoleArn = a.RoleArn
 		dbAwsAccount.External = a.External
-		err := dbAwsAccount.Update(tx)
+		err = dbAwsAccount.Update(tx)
 		if err != nil {
 			logger.Error("Failed to update AWS account in database.", err.Error())
 		}

--- a/aws/routes/routeAwsPatch.go
+++ b/aws/routes/routeAwsPatch.go
@@ -64,7 +64,7 @@ func patchAwsAccountWithValidBody(r *http.Request, tx *sql.Tx, user users.User, 
 		awsAccount.Pretty = body.Pretty
 		awsAccount.Payer = body.Payer
 		awsAccount.RoleArn = body.RoleArn
-		if err := awsAccount.UpdatePrettyAwsAccount(ctx, tx); err != nil {
+		if err = awsAccount.UpdatePrettyAwsAccount(ctx, tx); err != nil {
 			logger.Error("failed to update AWS Account", err)
 			return http.StatusInternalServerError, errFailUpdateAccount
 		}

--- a/es/awsClientSigner.go
+++ b/es/awsClientSigner.go
@@ -50,16 +50,16 @@ func checkParametersError(endpointMetaData []string, creds *credentials.Credenti
 //		- endpoint: The endpoint URI gettable from AWS.
 //		- creds: Credentials from AWS/Credentials.
 func NewSignedElasticClient(endpoint string, creds *credentials.Credentials) (*elastic.Client, error) {
-	if cofs, err := NewSignedElasticClientOptions(endpoint, creds); err == nil {
-		cof := configEach(cofs...)
-		if ec, err := elastic.NewClient(elastic.SetURL(endpoint), cof); err == nil {
-			return ec, nil
-		} else {
-			return nil, err
-		}
-	} else {
+	cofs, err := NewSignedElasticClientOptions(endpoint, creds)
+	if err != nil {
 		return nil, err
 	}
+	cof := configEach(cofs...)
+	ec, err := elastic.NewClient(elastic.SetURL(endpoint), cof)
+	if err != nil {
+ 		return nil, err
+	}
+	return ec, nil
 }
 
 // NewSignedElasticClientOptions builds elastic client option funcs which

--- a/reports/report_generation.go
+++ b/reports/report_generation.go
@@ -62,17 +62,17 @@ func GenerateReport(ctx context.Context, aa aws.AwsAccount, aas []aws.AwsAccount
 	}
 	errs = make(map[string]error)
 	file := createSpreadsheet(aa, reportDate)
-	if tx, err := db.Db.BeginTx(ctx, nil); err == nil {
+	if tx, err := db.Db.BeginTx(ctx, nil); err != nil {
+		errs["speadsheetError"] = err
+	} else {
 		for _, module := range modules {
-			err := module.GenerateSheet(ctx, aas, date, tx, file.File)
+			err = module.GenerateSheet(ctx, aas, date, tx, file.File)
 			if err != nil {
 				errs[module.ErrorName] = err
 			}
 		}
 		file.File.DeleteSheet(file.File.GetSheetName(1))
 		errs["speadsheetError"] = saveSpreadsheet(ctx, file, reportType)
-	} else {
-		errs["speadsheetError"] = err
 	}
 	return
 }
@@ -110,15 +110,15 @@ func GenerateTagsReport(ctx context.Context, aa aws.AwsAccount, aas []aws.AwsAcc
 	}
 	errs = make(map[string]error)
 	file := createSpreadsheet(aa, reportDate)
-	if tx, err := db.Db.BeginTx(ctx, nil); err == nil {
-		err := generateTagsUsageReportSheet(ctx, aas, date, tx, file.File)
+	if tx, err := db.Db.BeginTx(ctx, nil); err != nil {
+		errs["speadsheetError"] = err
+	} else {
+		err = generateTagsUsageReportSheet(ctx, aas, date, tx, file.File)
 		if err != nil {
 			errs["tagsError"] = err
 		}
 		file.File.DeleteSheet(file.File.GetSheetName(1))
 		errs["speadsheetError"] = saveSpreadsheet(ctx, file, TagsReport)
-	} else {
-		errs["speadsheetError"] = err
 	}
 	return
 }

--- a/server/taskAnomaliesDetection.go
+++ b/server/taskAnomaliesDetection.go
@@ -63,10 +63,12 @@ func processAnomaliesForAccount(ctx context.Context, aaId int) (err error) {
 			}
 		}
 	}()
+
+	var user *models.User // We can't use := because then there would be a new err which would shadow the returned value
 	if tx, err = db.Db.BeginTx(ctx, nil); err != nil {
 	} else if dbaa, err = models.AwsAccountByID(tx, aaId); err != nil {
 	} else if aa = aws.AwsAccountFromDbAwsAccount(*dbaa); err != nil {
-	} else if user, err := models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
+	} else if user, err = models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
 		if err == nil {
 			logger.Info("Task 'AnomaliesDetection' has been skipped because the user has the wrong account type.", map[string]interface{}{
 				"userAccountType": user.AccountType,

--- a/server/taskCheckCost.go
+++ b/server/taskCheckCost.go
@@ -66,9 +66,11 @@ func prepareCheckCostForAccount(ctx context.Context, aaId int) (err error) {
 			}
 		}
 	}()
+
+	var user *models.User // We can't use := because then there would be a new err which would shadow the returned value
 	if tx, err = db.Db.BeginTx(ctx, nil); err != nil {
 	} else if aa, err = taws.GetAwsAccountWithId(aaId, tx); err != nil {
-	} else if user, err := models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
+	} else if user, err = models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
 		if err == nil {
 			logger.Info("Task 'CheckCost' has been skipped because the user has the wrong account type.", map[string]interface{}{
 				"userAccountType": user.AccountType,

--- a/server/taskIngest.go
+++ b/server/taskIngest.go
@@ -68,9 +68,11 @@ func ingestBillingDataForBillRepository(ctx context.Context, aaId, brId int) (er
 			}
 		}
 	}()
+
+	var user *models.User // We can't use := because then there would be a new err which would shadow the returned value
 	if tx, err = db.Db.BeginTx(ctx, nil); err != nil {
 	} else if aa, err = aws.GetAwsAccountWithId(aaId, tx); err != nil {
-	} else if user, err := models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
+	} else if user, err = models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
 		if err == nil {
 			logger.Info("Task 'Ingest' has been skipped because the user has the wrong account type.", map[string]interface{}{
 				"userAccountType": user.AccountType,

--- a/server/taskIngestLimit.go
+++ b/server/taskIngestLimit.go
@@ -79,9 +79,11 @@ func ingestBillingDataForBillRepositoryLimit(ctx context.Context, aaId, brId int
 			}
 		}
 	}()
+
+	var user *models.User // We can't use := because then there would be a new err which would shadow the returned value
 	if tx, err = db.Db.BeginTx(ctx, nil); err != nil {
 	} else if aa, err = aws.GetAwsAccountWithId(aaId, tx); err != nil {
-	} else if user, err := models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
+	} else if user, err = models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
 		if err == nil {
 			logger.Info("Task 'IngestLimit' has been skipped because the user has the wrong account type.", map[string]interface{}{
 				"userAccountType": user.AccountType,

--- a/server/taskMasterSpreadsheet.go
+++ b/server/taskMasterSpreadsheet.go
@@ -60,9 +60,12 @@ func generateMasterReport(ctx context.Context, aaId int, date time.Time) (err er
 			}
 		}
 	}()
+
+	var user *models.User // We can't use := because then there would be a new err which would shadow the returned value
+	var dbAccounts []*models.AwsAccount
 	if tx, err = db.Db.BeginTx(ctx, nil); err != nil {
 	} else if aa, err = aws.GetAwsAccountWithId(aaId, tx); err != nil {
-	} else if user, err := models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
+	} else if user, err = models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
 		if err == nil {
 			logger.Info("Task 'MasterSpreadSheet' has been skipped because the user has the wrong account type.", map[string]interface{}{
 				"userAccountType": user.AccountType,
@@ -71,7 +74,7 @@ func generateMasterReport(ctx context.Context, aaId int, date time.Time) (err er
 		}
 	} else if generation, err = checkMasterReportGeneration(ctx, db.Db, aa, forceGeneration); err != nil || !generation {
 	} else if updateId, err = registerMasterAccountReportGeneration(db.Db, aa); err != nil {
-	} else if dbAccounts, err := getAccounts(ctx, db.Db, aa); err != nil {
+	} else if dbAccounts, err = getAccounts(ctx, db.Db, aa); err != nil {
 	} else {
 		accounts := make([]aws.AwsAccount, 0)
 		for _, dbAccount := range dbAccounts {
@@ -194,7 +197,8 @@ func registerMasterAccountReportGenerationCompletion(db *sql.DB, aaId int, updat
 		return err
 	}
 	if !forceGeneration {
-		dbAccount, err := models.AwsAccountByID(db, aaId)
+		var dbAccount *models.AwsAccount  // We can't use := because then there would be a new err which would shadow the returned value
+		dbAccount, err = models.AwsAccountByID(db, aaId)
 		if err != nil {
 			return err
 		}

--- a/server/taskProcessAccountPlugins.go
+++ b/server/taskProcessAccountPlugins.go
@@ -67,9 +67,11 @@ func preparePluginsProcessingForAccount(ctx context.Context, aaId int) (err erro
 			}
 		}
 	}()
+
+	var trackitUser *models.User // We can't use := because then there would be a new err which would shadow the returned value
 	if tx, err = db.Db.BeginTx(ctx, nil); err != nil {
 	} else if aa, err = aws.GetAwsAccountWithId(aaId, tx); err != nil {
-	} else if trackitUser, err := models.UserByID(db.Db, aa.UserId); err != nil || trackitUser.AccountType != "trackit" {
+	} else if trackitUser, err = models.UserByID(db.Db, aa.UserId); err != nil || trackitUser.AccountType != "trackit" {
 		if err == nil {
 			logger.Info("Task 'ProcessAccountPlugins' has been skipped because the user has the wrong account type.", map[string]interface{}{
 				"userAccountType": trackitUser.AccountType,

--- a/server/taskSpreadsheet.go
+++ b/server/taskSpreadsheet.go
@@ -86,9 +86,11 @@ func generateReport(ctx context.Context, aaId int, date time.Time) (err error) {
 			}
 		}
 	}()
+
+	var user *models.User // We can't use := because then there would be a new err which would shadow the returned value
 	if tx, err = db.Db.BeginTx(ctx, nil); err != nil {
 	} else if aa, err = aws.GetAwsAccountWithId(aaId, tx); err != nil {
-	} else if user, err := models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
+	} else if user, err = models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
 		if err == nil {
 			logger.Info("Task 'SpreadSheet' has been skipped because the user has the wrong account type.", map[string]interface{}{
 				"userAccountType": user.AccountType,
@@ -220,7 +222,8 @@ func registerAccountReportGenerationCompletion(db *sql.DB, aaId int, updateId in
 		return err
 	}
 	if !forceGeneration {
-		dbAccount, err := models.AwsAccountByID(db, aaId)
+		var dbAccount *models.AwsAccount // We can't use := because then there would be a new err which would shadow the returned value
+		dbAccount, err = models.AwsAccountByID(db, aaId)
 		if err != nil {
 			return err
 		}

--- a/server/taskSpreadsheetTags.go
+++ b/server/taskSpreadsheetTags.go
@@ -59,9 +59,11 @@ func generateTagsReport(ctx context.Context, aaId int, date time.Time) (err erro
 			}
 		}
 	}()
+
+	var user *models.User // We can't use := because then there would be a new err which would shadow the returned value
 	if tx, err = db.Db.BeginTx(ctx, nil); err != nil {
 	} else if aa, err = aws.GetAwsAccountWithId(aaId, tx); err != nil {
-	} else if user, err := models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
+	} else if user, err = models.UserByID(db.Db, aa.UserId); err != nil || user.AccountType != "trackit" {
 		if err == nil {
 			logger.Info("Task 'SpreadSheetTags' has been skipped because the user has the wrong account type.", map[string]interface{}{
 				"userAccountType": user.AccountType,
@@ -150,7 +152,8 @@ func registerAccountTagsReportGenerationCompletion(db *sql.DB, aaId int, updateI
 		return err
 	}
 	if !forceGeneration {
-		dbAccount, err := models.AwsAccountByID(db, aaId)
+		var dbAccount *models.AwsAccount // We can't use := because then there would be a new err which would shadow the returned value
+		dbAccount, err = models.AwsAccountByID(db, aaId)
 		if err != nil {
 			return err
 		}

--- a/users/create.go
+++ b/users/create.go
@@ -176,53 +176,49 @@ func createUserWithValidBody(request *http.Request, body createUserRequestBody, 
 	ctx := request.Context()
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	user, err := CreateUserWithPassword(ctx, tx, body.Email, body.Password, customerIdentifier, body.Origin)
-	if err == nil {
-		logger.Info("User created.", user)
-		if err := entitlement.CheckUserEntitlements(request.Context(), tx, user.Id); err != nil {
-			logger.Error("Could not check new user's entitlements", map[string]interface{}{
-				"email":   body.Email,
-				"origin":  body.Origin,
-				"err":     err.Error(),
-			})
-		}
-		return 200, user
-	} else {
+	if err != nil {
 		logger.Error(err.Error(), nil)
 		errSplit := strings.Split(err.Error(), ":")
 		if len(errSplit) >= 1 && errSplit[0] == "Error 1062" {
 			return 409, errors.New("Account already exists.")
-		} else {
-			return 500, errors.New("Failed to create user.")
 		}
+		return 500, errors.New("Failed to create user.")
 	}
+	logger.Info("User created.", user)
+	if err = entitlement.CheckUserEntitlements(request.Context(), tx, user.Id); err != nil {
+		logger.Error("Could not check new user's entitlements", map[string]interface{}{
+			"email":   body.Email,
+			"origin":  body.Origin,
+			"err":     err.Error(),
+		})
+	}
+	return 200, user
 }
 
 func createTagbotUserWithValidBody(request *http.Request, body createUserRequestBody, tx *sql.Tx, customerIdentifier string) (int, interface{}) {
 	ctx := request.Context()
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	user, err := CreateUserWithPassword(ctx, tx, body.Email, body.Password, "", body.Origin)
-	if err == nil {
-		logger.Info("User created.", user)
-		if err := CreateTagbotUser(ctx, tx, user.Id, customerIdentifier); err != nil {
-			return 500, errors.New("Failed to create user.")
-		}
-		if err := entitlement.CheckUserEntitlements(request.Context(), tx, user.Id); err != nil {
-			logger.Error("Could not check new user's entitlements", map[string]interface{}{
-				"email":   body.Email,
-				"origin":  body.Origin,
-				"err":     err.Error(),
-			})
-		}
-		return 200, user
-	} else {
+	if err != nil {
 		logger.Error(err.Error(), nil)
 		errSplit := strings.Split(err.Error(), ":")
 		if len(errSplit) >= 1 && errSplit[0] == "Error 1062" {
 			return 409, errors.New("Account already exists.")
-		} else {
-			return 500, errors.New("Failed to create user.")
 		}
+		return 500, errors.New("Failed to create user.")
 	}
+	logger.Info("User created.", user)
+	if err = CreateTagbotUser(ctx, tx, user.Id, customerIdentifier); err != nil {
+		return 500, errors.New("Failed to create user.")
+	}
+	if err = entitlement.CheckUserEntitlements(request.Context(), tx, user.Id); err != nil {
+		logger.Error("Could not check new user's entitlements", map[string]interface{}{
+			"email":   body.Email,
+			"origin":  body.Origin,
+			"err":     err.Error(),
+		})
+ 	}
+	return 200, user
 }
 
 type createViewerUserRequestBody struct {

--- a/users/login.go
+++ b/users/login.go
@@ -83,7 +83,7 @@ func logAuthenticatedUserIn(request *http.Request, user User) (int, interface{})
 	logger := jsonlog.LoggerFromContextOrDefault(request.Context())
 	token, err := generateToken(user)
 	if err == nil {
-		if err := updateLastSeen(user); err != nil {
+		if err = updateLastSeen(user); err != nil {
 			logger.Error("Could not update last seen for user.", map[string]interface{}{
 				"email": user.Email,
 				"err":   err,

--- a/users/users.go
+++ b/users/users.go
@@ -180,16 +180,15 @@ func (u User) Delete() error {
 // UpdatePassword updates a user's password. A nil error indicates a success.
 func (u User) UpdatePassword(db models.XODB, password string) error {
 	dbUser, err := models.UserByID(db, u.Id)
-	if err == nil {
-		auth, err := getPasswordHash(password)
-		if err != nil {
-			return err
-		}
-		dbUser.Auth = auth
-		return dbUser.Update(db)
-	} else {
+	if err != nil {
 		return err
 	}
+	auth, err := getPasswordHash(password)
+	if err != nil {
+ 		return err
+ 	}
+	dbUser.Auth = auth
+	return dbUser.Update(db)
 }
 
 // PasswordMatches tests whether a password matches a user's stored hash. A nil


### PR DESCRIPTION
A bunch of these changes aren't straight up bug fixes (though most of them are), but they keep the shadowing to a minimum while refactoring the code to better correspond to the recommended guidelines on writing Go code. Otherwise, most of the bug fixes are about `err` getting shadowed before further usage, which can be pretty bad when it results in no error being returned in a situation where one occured.

Note that while `:=` will usually only redeclare (and thus not truly shadow) an existing identifier, this does not apply when the identifier is not from the same scope. `if` statements do in fact introduce a new scope even in the preceding statement (i.e. `stmt` in `if stmt; cond {}` in not in the same scope as the code containing the `if`), which is the cause of many of the bugs here.