### PR TITLE
General cleanup of somewhat minor issues in aws/usageReports

### DIFF
--- a/aws/usageReports/ebs/monthlyReport.go
+++ b/aws/usageReports/ebs/monthlyReport.go
@@ -218,7 +218,7 @@ func PutEbsMonthlyReport(ctx context.Context, ec2Cost []utils.CostPerResource, a
 
 //get the region of the ressource for ebs snapshot
 func getResourceRegion(cost utils.CostPerResource) string {
-	reg, err := regexp.Compile("^arn:aws:ec2:([\\w\\d\\-]+):\\d+:snapshot")
+	reg, err := regexp.Compile(`^arn:aws:ec2:([\w\d\-]+):\d+:snapshot`)
 	if err != nil {
 		return ""
 	}
@@ -227,7 +227,7 @@ func getResourceRegion(cost utils.CostPerResource) string {
 
 //get the id of the ressource for ebs snapshot
 func getResourceId(cost utils.CostPerResource) string {
-	reg, err := regexp.Compile("^arn:aws:ec2:[\\w\\d\\-]+:\\d+:snapshot/([\\w\\d\\-]+)")
+	reg, err := regexp.Compile(`^arn:aws:ec2:[\w\d\-]+:\d+:snapshot/([\w\d\-]+)`)
 	if err != nil {
 		return ""
 	}

--- a/aws/usageReports/ec2/dailyReport.go
+++ b/aws/usageReports/ec2/dailyReport.go
@@ -48,7 +48,7 @@ func fetchDailyInstancesList(ctx context.Context, creds *credentials.Credentials
 	for _, reservation := range instances.Reservations {
 		for _, instance := range reservation.Instances {
 			stats := getInstanceStats(ctx, instance, sess, start, end)
-			costs := make(map[string]float64, 0)
+			costs := make(map[string]float64)
 			instanceChan <- Instance{
 				InstanceBase: InstanceBase{
 					Id:         aws.StringValue(instance.InstanceId),

--- a/aws/usageReports/ec2/monthlyReport.go
+++ b/aws/usageReports/ec2/monthlyReport.go
@@ -127,7 +127,7 @@ func fetchMonthlyInstancesList(ctx context.Context, creds *credentials.Credentia
 	for _, reservation := range instances.Reservations {
 		for _, instance := range reservation.Instances {
 			stats := getInstanceStats(ctx, instance, sess, startDate, endDate)
-			costs := make(map[string]float64)
+			costs := make(map[string]float64, 1)
 			costs["instance"] = inst.Cost
 			instanceChan <- Instance{
 				InstanceBase: InstanceBase{

--- a/aws/usageReports/ec2/monthlyReport.go
+++ b/aws/usageReports/ec2/monthlyReport.go
@@ -78,7 +78,7 @@ func getInstanceInfoFromES(ctx context.Context, instance utils.CostPerResource, 
 			Platform:   "Linux/UNIX",
 		},
 		Tags:  make([]utils.Tag, 0),
-		Costs: make(map[string]float64, 0),
+		Costs: make(map[string]float64),
 		Stats: Stats{
 			Cpu: Cpu{
 				Average: -1,
@@ -127,7 +127,7 @@ func fetchMonthlyInstancesList(ctx context.Context, creds *credentials.Credentia
 	for _, reservation := range instances.Reservations {
 		for _, instance := range reservation.Instances {
 			stats := getInstanceStats(ctx, instance, sess, startDate, endDate)
-			costs := make(map[string]float64, 0)
+			costs := make(map[string]float64)
 			costs["instance"] = inst.Cost
 			instanceChan <- Instance{
 				InstanceBase: InstanceBase{

--- a/aws/usageReports/elasticache/dailyReport.go
+++ b/aws/usageReports/elasticache/dailyReport.go
@@ -48,7 +48,7 @@ func fetchDailyInstancesList(ctx context.Context, creds *credentials.Credentials
 	}
 	for _, cluster := range instances.CacheClusters {
 		stats := getInstanceStats(ctx, cluster, sess, start, end)
-		costs := make(map[string]float64, 0)
+		costs := make(map[string]float64)
 		tags := getClusterTags(ctx, cluster, svc, account, region)
 		instanceChan <- Instance{
 			InstanceBase: InstanceBase{

--- a/aws/usageReports/elasticache/monthlyReport.go
+++ b/aws/usageReports/elasticache/monthlyReport.go
@@ -47,7 +47,7 @@ func fetchMonthlyInstancesList(ctx context.Context, creds *credentials.Credentia
 	}
 	for _, cluster := range instances.CacheClusters {
 		stats := getInstanceStats(ctx, cluster, sess, startDate, endDate)
-		costs := make(map[string]float64, 0)
+		costs := make(map[string]float64)
 		costs[inst.Resource] = inst.Cost
 		tags := getClusterTags(ctx, cluster, svc, account, region)
 		instanceChan <- Instance{

--- a/aws/usageReports/elasticache/monthlyReport.go
+++ b/aws/usageReports/elasticache/monthlyReport.go
@@ -47,7 +47,7 @@ func fetchMonthlyInstancesList(ctx context.Context, creds *credentials.Credentia
 	}
 	for _, cluster := range instances.CacheClusters {
 		stats := getInstanceStats(ctx, cluster, sess, startDate, endDate)
-		costs := make(map[string]float64)
+		costs := make(map[string]float64, 1)
 		costs[inst.Resource] = inst.Cost
 		tags := getClusterTags(ctx, cluster, svc, account, region)
 		instanceChan <- Instance{

--- a/aws/usageReports/es/dailyReport.go
+++ b/aws/usageReports/es/dailyReport.go
@@ -81,7 +81,7 @@ func fetchDailyDomainsList(ctx context.Context, creds *credentials.Credentials, 
 				Region:            region,
 			},
 			Tags:  tags,
-			Costs: make(map[string]float64, 0),
+			Costs: make(map[string]float64),
 			Stats: stats,
 		}
 	}

--- a/aws/usageReports/es/monthlyReport.go
+++ b/aws/usageReports/es/monthlyReport.go
@@ -54,7 +54,7 @@ func fetchMonthlyDomainsList(ctx context.Context, creds *credentials.Credentials
 		tags = getDomainTag(esTags.TagList)
 	}
 	stats := getDomainStats(ctx, *domain.DomainName, sess, start, end)
-	costs := make(map[string]float64, 0)
+	costs := make(map[string]float64)
 	costs["domain"] = dom.Cost
 	domainChan <- Domain{
 		DomainBase: DomainBase{

--- a/aws/usageReports/es/monthlyReport.go
+++ b/aws/usageReports/es/monthlyReport.go
@@ -54,7 +54,7 @@ func fetchMonthlyDomainsList(ctx context.Context, creds *credentials.Credentials
 		tags = getDomainTag(esTags.TagList)
 	}
 	stats := getDomainStats(ctx, *domain.DomainName, sess, start, end)
-	costs := make(map[string]float64)
+	costs := make(map[string]float64, 1)
 	costs["domain"] = dom.Cost
 	domainChan <- Domain{
 		DomainBase: DomainBase{

--- a/aws/usageReports/history/history.go
+++ b/aws/usageReports/history/history.go
@@ -42,7 +42,7 @@ const numPartition = 5
 var ErrBillingDataIncomplete = errors.New("Billing data are not completed")
 
 type (
-	// structures that allows to parse ES result
+	// EsRegionPerResourceResult allows us to parse ES results
 	EsRegionPerResourceResult struct {
 		Resources struct {
 			Buckets []struct {

--- a/aws/usageReports/instanceCount/utils.go
+++ b/aws/usageReports/instanceCount/utils.go
@@ -29,7 +29,7 @@ import (
 )
 
 type (
-	// InstanceCount is saved in ES to have all the information of an InstanceCount
+	// InstanceCountReport is saved in ES to have all the information of an InstanceCount
 	InstanceCountReport struct {
 		utils.ReportBase
 		InstanceCount InstanceCount `json:"instanceCount"`

--- a/aws/usageReports/rds/dailyReport.go
+++ b/aws/usageReports/rds/dailyReport.go
@@ -58,14 +58,14 @@ func fetchDailyInstancesList(ctx context.Context, creds *credentials.Credentials
 				MultiAZ:              aws.BoolValue(DBInstance.MultiAZ),
 			},
 			Tags:  tags,
-			Costs: make(map[string]float64, 0),
+			Costs: make(map[string]float64),
 			Stats: stats,
 		}
 	}
 	return nil
 }
 
-// FetchDailyInstanceStats retrieves RDS information from the AWS API and generates a report
+// FetchDailyInstancesStats retrieves RDS information from the AWS API and generates a report
 func FetchDailyInstancesStats(ctx context.Context, aa taws.AwsAccount) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching RDS instance stats", map[string]interface{}{"awsAccountId": aa.Id})

--- a/aws/usageReports/rds/monthlyReport.go
+++ b/aws/usageReports/rds/monthlyReport.go
@@ -47,7 +47,7 @@ func fetchMonthlyInstancesList(ctx context.Context, creds *credentials.Credentia
 	for _, DBInstance := range instances.DBInstances {
 		tags := getInstanceTags(ctx, DBInstance, svc)
 		stats := getInstanceStats(ctx, DBInstance, sess, startDate, endDate)
-		costs := make(map[string]float64, 0)
+		costs := make(map[string]float64)
 		costs["instance"] = inst.Cost
 		instanceChan <- Instance{
 			InstanceBase: InstanceBase{

--- a/aws/usageReports/rds/monthlyReport.go
+++ b/aws/usageReports/rds/monthlyReport.go
@@ -47,7 +47,7 @@ func fetchMonthlyInstancesList(ctx context.Context, creds *credentials.Credentia
 	for _, DBInstance := range instances.DBInstances {
 		tags := getInstanceTags(ctx, DBInstance, svc)
 		stats := getInstanceStats(ctx, DBInstance, sess, startDate, endDate)
-		costs := make(map[string]float64)
+		costs := make(map[string]float64, 1)
 		costs["instance"] = inst.Cost
 		instanceChan <- Instance{
 			InstanceBase: InstanceBase{

--- a/aws/usageReports/riRdS/dailyReport.go
+++ b/aws/usageReports/riRdS/dailyReport.go
@@ -67,7 +67,7 @@ func fetchDailyInstancesList(ctx context.Context, creds *credentials.Credentials
 	return nil
 }
 
-// FetchDailyInstanceStats retrieves RDS information from the AWS API and generates a report
+// FetchDailyInstancesStats retrieves RDS information from the AWS API and generates a report
 func FetchDailyInstancesStats(ctx context.Context, aa taws.AwsAccount) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	logger.Info("Fetching Reserved RDS instance stats", map[string]interface{}{"awsAccountId": aa.Id})

--- a/aws/usageReports/utils.go
+++ b/aws/usageReports/utils.go
@@ -38,7 +38,7 @@ type (
 		Region   string
 	}
 
-	// BaseReport contains basic information for any kin of usage report
+	// ReportBase contains basic information for any kin of usage report
 	ReportBase struct {
 		Account    string    `json:"account"`
 		ReportDate time.Time `json:"reportDate"`
@@ -128,7 +128,7 @@ func GetAccountId(ctx context.Context, sess *session.Session) (string, error) {
 	return aws.StringValue(res.Account), nil
 }
 
-// GetCurrentCheckDay returns the actual date at midnight and this date the month before
+// GetCurrentCheckedDay returns the actual date at midnight and this date the month before
 func GetCurrentCheckedDay() (start time.Time, end time.Time) {
 	now := time.Now().UTC()
 	end = time.Date(now.Year(), now.Month(), now.Day()-1, 24, 0, 0, 0, now.Location())


### PR DESCRIPTION
Poor regex quoting, bad make(map[T]T, 0) usage and comments that are not up to norm (especially w.r.t. using the right names for what they refer to), it's all minor stuff but still, worth fixing