### PR TITLE
General cleanup and optimization of minor issues

### DIFF
--- a/anomaliesDetection/bollinger.go
+++ b/anomaliesDetection/bollinger.go
@@ -55,8 +55,7 @@ func sigma(aCosts AnalyzedCosts, avg float64) float64 {
 
 // deviation calculates the standard deviation.
 func deviation(sigma float64, period int) float64 {
-	var deviation float64
-	deviation = 1 / float64(period) * math.Pow(sigma, 0.5)
+	var deviation float64 = 1 / float64(period) * math.Pow(sigma, 0.5)
 	return deviation
 }
 

--- a/anomaliesDetection/products.go
+++ b/anomaliesDetection/products.go
@@ -88,7 +88,8 @@ func runAnomaliesDetectionForProducts(parsedParams AnomalyEsQueryParams, account
 	var res AnalyzedCosts
 	if res, err = productGetAnomaliesData(ctx, parsedParams); err != nil {
 	} else if err = productSaveAnomaliesData(ctx, res, account); err != nil {
-	} else if err = removeRecurrence(ctx, parsedParams, account); err != nil {
+	} else {
+		err = removeRecurrence(ctx, parsedParams, account)
 	}
 	return
 }

--- a/anomaliesDetection/products_recurrence.go
+++ b/anomaliesDetection/products_recurrence.go
@@ -134,7 +134,9 @@ func getAnomaliesFromEs(ctx context.Context, params AnomalyEsQueryParams) (esPro
 	for i, h := range sr.Hits.Hits {
 		typedDocuments[i].Id = h.Id
 		if b, err := h.Source.MarshalJSON(); err != nil {
+			logger.Error("Failed to marshal one of the documents", map[string]interface{}{"document": h.Source})
 		} else if err := json.Unmarshal(b, &typedDocuments[i].Source); err != nil {
+			logger.Error("Failed to unmarshal one of the documents", map[string]interface{}{"document": string(b)})
 		}
 	}
 	return typedDocuments, nil

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -71,7 +71,7 @@ func initAccountId(s *sts.STS) string {
 // AccountId returns the server's AWS account ID.
 func AccountId() string { return accountId }
 
-// GetAwsAccountFromUser returns a slice of all AWS accounts configured by a
+// GetAwsAccountsFromUser returns a slice of all AWS accounts configured by a
 // given user.
 func GetAwsAccountsFromUser(u users.User, tx *sql.Tx) ([]AwsAccount, error) {
 	var res []AwsAccount

--- a/aws/decorators.go
+++ b/aws/decorators.go
@@ -12,7 +12,7 @@ import (
 	"github.com/trackit/trackit/users"
 )
 
-// RequireAwsAccount decorates handler to require that an AwsAccount be
+// RequireAwsAccountId decorates handler to require that an AwsAccount be
 // selected using RequiredQueryArgs{AwsAccountIdQueryArg}. The decorator will
 // panic if no AwsAccountIdQueryArg query argument is found.
 type RequireAwsAccountId struct{}
@@ -28,7 +28,7 @@ func (d RequireAwsAccountId) Decorate(h routes.Handler) routes.Handler {
 	return h
 }
 
-func (_ RequireAwsAccountId) getFunc(hf routes.HandlerFunc) routes.HandlerFunc {
+func (RequireAwsAccountId) getFunc(hf routes.HandlerFunc) routes.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request, a routes.Arguments) (int, interface{}) {
 		l := jsonlog.LoggerFromContextOrDefault(r.Context())
 		user, tx, err := getUserAndTransactionFromArguments(a)

--- a/aws/pricings/fetchEc2Pricings.go
+++ b/aws/pricings/fetchEc2Pricings.go
@@ -264,11 +264,11 @@ func getRIStandardNoUpfrontCost(item aws.JSONValue, duration string) float64 {
 func FetchEc2Pricings(ctx context.Context) (EC2Pricing, error) {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	parsingError := false
-	ec2Pricings := EC2Pricing{Region: make(map[string]EC2Platform, 0)}
+	ec2Pricings := EC2Pricing{Region: make(map[string]EC2Platform, len(EC2RegionCodeToPricingLocationName))}
 	svc := getPricingClient()
 	for regionCode, locationName := range EC2RegionCodeToPricingLocationName {
 		logger.Info("Fetching pricings for region", map[string]interface{}{"region": regionCode})
-		ec2Pricings.Region[regionCode] = EC2Platform{Platform: make(map[string]EC2Type, 0)}
+		ec2Pricings.Region[regionCode] = EC2Platform{Platform: make(map[string]EC2Type)}
 		input := getPricingProductInput(locationName)
 		err := svc.GetProductsPages(input,
 			func(page *pricing.GetProductsOutput, lastPage bool) bool {
@@ -288,7 +288,7 @@ func FetchEc2Pricings(ctx context.Context) (EC2Pricing, error) {
 						continue
 					}
 					if _, ok := ec2Pricings.Region[regionCode].Platform[platform]; !ok {
-						ec2Pricings.Region[regionCode].Platform[platform] = EC2Type{Type: make(map[string]*EC2Specs, 0)}
+						ec2Pricings.Region[regionCode].Platform[platform] = EC2Type{Type: make(map[string]*EC2Specs, 1)}
 					}
 					if _, ok := ec2Pricings.Region[regionCode].Platform[platform].Type[instanceType]; !ok {
 						ec2Pricings.Region[regionCode].Platform[platform].Type[instanceType] = &EC2Specs{}

--- a/aws/routes/routeAwsGet.go
+++ b/aws/routes/routeAwsGet.go
@@ -170,10 +170,9 @@ func intArrayToSqlSet(integers []int) string {
 // The result is filtered by a slice of accountID
 func AwsAccountsFromUserIDByAccountID(db models.XODB, userID int, accountIDs []int) ([]aws.AwsAccount, error) {
 	var err error
-	var stringAccountIDs []string
 
 	// gen account_id
-	stringAccountIDs = intArrayToStringArray(accountIDs)
+	stringAccountIDs := intArrayToStringArray(accountIDs)
 	accountID := "(" + strings.Join(stringAccountIDs, ",") + ")"
 
 	// sql query

--- a/aws/routes/routeAwsStatus.go
+++ b/aws/routes/routeAwsStatus.go
@@ -30,7 +30,7 @@ func getAwsAccountsStatus(r *http.Request, a routes.Arguments) (int, interface{}
 		l.Error("failed to get AWS accounts' bill repositories", err.Error())
 		return 500, errors.New("failed to retrieve bill repositories")
 	}
-	// Code unneeded for now
+	// Code unneeded for now considering all it does is create an array and fill it with all the id data from the AWS stuff before proceeding to do nothing with it
 	/*
 	billRepositoriesIds := make([]int, 0)
 	for _, awsAccount := range awsAccountsWithBillRepositories {

--- a/aws/routes/routeAwsStatus.go
+++ b/aws/routes/routeAwsStatus.go
@@ -30,12 +30,15 @@ func getAwsAccountsStatus(r *http.Request, a routes.Arguments) (int, interface{}
 		l.Error("failed to get AWS accounts' bill repositories", err.Error())
 		return 500, errors.New("failed to retrieve bill repositories")
 	}
+	// Code unneeded for now
+	/*
 	billRepositoriesIds := make([]int, 0)
 	for _, awsAccount := range awsAccountsWithBillRepositories {
 		for _, billRepository := range awsAccount.BillRepositories {
 			billRepositoriesIds = append(billRepositoriesIds, billRepository.Id)
 		}
 	}
+	*/
 	result := s3.WrapAwsAccountsWithBillRepositoriesWithPendingWithStatus(awsAccountsWithBillRepositories, tx)
 	return 200, result
 }

--- a/aws/s3/billRepository.go
+++ b/aws/s3/billRepository.go
@@ -123,7 +123,7 @@ func CreateBillRepository(aa aws.AwsAccount, br BillRepository, tx *sql.Tx) (Bil
 	return out, err
 }
 
-// UpdateBillRepository updates a BillRepository in the database
+// UpdateBillRepositorySafe updates a BillRepository in the database
 func UpdateBillRepositorySafe(dbBr *models.AwsBillRepository, br BillRepository, tx *sql.Tx) (BillRepository, error) {
 	dbBr.Prefix = br.Prefix
 	dbBr.Bucket = br.Bucket
@@ -230,7 +230,7 @@ func postBillRepository(r *http.Request, a routes.Arguments) (int, interface{}) 
 	var body postBillRepositoryBody
 	routes.MustRequestBody(a, &body)
 	if err := isBillRepositoryValid(body); err != nil {
-		return http.StatusBadRequest, errors.New(fmt.Sprintf("Body is invalid (%s).", err.Error()))
+		return http.StatusBadRequest, fmt.Errorf("Body is invalid (%s).", err.Error())
 	}
 	aa := a[aws.AwsAccountSelection].(aws.AwsAccount)
 	if err := isBillRepositoryAccessible(r.Context(), aa, body); err != nil {
@@ -264,7 +264,7 @@ func patchBillRepository(r *http.Request, a routes.Arguments) (int, interface{})
 	var body postBillRepositoryBody
 	routes.MustRequestBody(a, &body)
 	if err := isBillRepositoryValid(body); err != nil {
-		return http.StatusBadRequest, errors.New(fmt.Sprintf("Body is invalid (%s).", err.Error()))
+		return http.StatusBadRequest, fmt.Errorf("Body is invalid (%s).", err.Error())
 	}
 	aa := a[aws.AwsAccountSelection].(aws.AwsAccount)
 	if err := isBillRepositoryAccessible(r.Context(), aa, body); err != nil {
@@ -332,7 +332,7 @@ func isBucketNameValid(bn string) error {
 	} else if l > 63 {
 		return errors.New("bucket name shall be no longer than 63 chars")
 	} else if !noTwoDotsInBucketName.MatchString(bn) {
-		return errors.New(fmt.Sprintf("bucket name shall satisfy the regexp /%s/", noTwoDotsInBucketNameRegex))
+		return fmt.Errorf("bucket name shall satisfy the regexp /%s/", noTwoDotsInBucketNameRegex)
 	} else {
 		return nil
 	}

--- a/aws/s3/readBills.go
+++ b/aws/s3/readBills.go
@@ -414,7 +414,7 @@ func listBillsFromRepositoryPage(
 	return func(page *s3.ListObjectsV2Output, last bool) bool {
 		for _, o := range page.Contents {
 			if brr.LastImportedManifest.Before((*o.LastModified).AddDate(0, 1, 0)) {
-				count += 1
+				count++
 				select {
 				case c <- BillKey{
 					Key:          *o.Key,
@@ -450,7 +450,7 @@ func getBucketRegion(ctx context.Context, sess *session.Session, r BillRepositor
 	})
 	if output, err := s3svc.GetBucketLocationWithContext(ctx, &input); err == nil {
 		region := getBucketRegionFromGetBucketLocationOutput(output)
-		logger.Debug(fmt.Sprintf("Found bucket region."), map[string]string{
+		logger.Debug("Found bucket region.", map[string]string{
 			"bucket": r.Bucket,
 			"region": region,
 		})

--- a/aws/usageReports/rds/monthlyReport.go
+++ b/aws/usageReports/rds/monthlyReport.go
@@ -47,7 +47,7 @@ func fetchMonthlyInstancesList(ctx context.Context, creds *credentials.Credentia
 	for _, DBInstance := range instances.DBInstances {
 		tags := getInstanceTags(ctx, DBInstance, svc)
 		stats := getInstanceStats(ctx, DBInstance, sess, startDate, endDate)
-		costs := make(map[string]float64, 0)
+		costs := make(map[string]float64, 1)
 		costs["instance"] = inst.Cost
 		instanceChan <- Instance{
 			InstanceBase: InstanceBase{

--- a/cache/local.go
+++ b/cache/local.go
@@ -107,9 +107,7 @@ func initialiseCacheInfos(url string, args routes.Arguments, logger jsonlog.Logg
 			return
 		}
 	}
-	for _, val := range allAcc {
-		rtn.awsAccount = append(rtn.awsAccount, val)
-	}
+	rtn.awsAccount = append(rtn.awsAccount, allAcc...)
 	sort.Strings(rtn.awsAccount)
 	formatKey(&rtn)
 	return

--- a/costs/diff/diff.go
+++ b/costs/diff/diff.go
@@ -40,7 +40,7 @@ type costDiff map[string][]PricePoint
 func (cd costDiff) ToCSVable() [][]string {
 	csv := [][]string{}
 	keys := []string{}
-	for k, _ := range cd {
+	for k := range cd {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
@@ -70,7 +70,7 @@ func (cd costDiff) ToCSVable() [][]string {
 // getVariations compute the percentage of variation between each pair of consecutive
 // week/month in the interval selected by the user.
 func getVariations(pricePoints []PricePoint) []PricePoint {
-	for i := 1; i < len(pricePoints); i += 1 {
+	for i := 1; i < len(pricePoints); i++ {
 		if pricePoints[i-1].Cost == 0.0 {
 			pricePoints[i].PercentVariation = 0.0
 		} else {

--- a/costs/tags/tags_keys.go
+++ b/costs/tags/tags_keys.go
@@ -38,7 +38,7 @@ type (
 		} `json:"keys"`
 	}
 
-	// result format of the endpoint
+	// TagsKeys is the result format of the endpoint
 	TagsKeys []string
 )
 

--- a/costs/tags/tags_values.go
+++ b/costs/tags/tags_values.go
@@ -71,7 +71,7 @@ type (
 		} `json:"buckets"`
 	}
 
-	// contain a product and his cost
+	// TagValue contains a product and its cost
 	TagValue struct {
 		Item string  `json:"item"`
 		Cost float64 `json:"cost"`
@@ -87,20 +87,19 @@ type (
 		UsageTypes []ValueDetailed `json:"usagetypes"`
 	}
 
-	// contain a tag and the list of products associated
+	// TagsValues contains a tag and the list of products associated
 	TagsValues struct {
 		Tag   string             `json:"tag"`
 		Costs []TagValue         `json:"costs,omitempty"`
 		Items []TagValueDetailed `json:"items,omitempty"`
 	}
 
-	// response format of the endpoint
+	// TagsValuesResponse is the response format of the endpoint
 	TagsValuesResponse map[string][]TagsValues
 )
 
 // GetTagsValuesWithParsedParams will parse the data from ElasticSearch and return it
 func GetTagsValuesWithParsedParams(ctx context.Context, params TagsValuesQueryParams) (int, TagsValuesResponse, error) {
-	response := TagsValuesResponse{}
 	l := jsonlog.LoggerFromContextOrDefault(ctx)
 	var typedDocument esTagsValuesDetailedResult
 	res, returnCode, err := makeElasticSearchRequestForTagsValues(ctx, params, es.Client)
@@ -115,6 +114,8 @@ func GetTagsValuesWithParsedParams(ctx context.Context, params TagsValuesQueryPa
 		l.Error("Error while unmarshaling", err)
 		return http.StatusInternalServerError, nil, errors.GetErrorMessage(ctx, err)
 	}
+
+	var response TagsValuesResponse
 	if params.Detailed == true {
 		response = getTagsResponseDetailed(typedDocument, params)
 	} else {

--- a/db/db.go
+++ b/db/db.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"time"
 
+	// We need the MySQL driver to register itself to be able to use database/sql properly
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/trackit/jsonlog"
 

--- a/db/decorator.go
+++ b/db/decorator.go
@@ -25,7 +25,7 @@ import (
 	"github.com/trackit/trackit/routes"
 )
 
-// Transaction is a decorator which manages a transaction for an HTTP request.
+// RequestTransaction is a decorator which manages a transaction for an HTTP request.
 // It will Commit the transaction if the handler returns something other than
 // an error and it did not panic; it Rollbacks otherwise.
 type RequestTransaction struct {

--- a/errors/database.go
+++ b/errors/database.go
@@ -46,10 +46,8 @@ func getDatabaseErrorMessage(ctx context.Context, err *DatabaseError) error {
 		} else {
 			formattedErr = errors.New("Error while getting data from database")
 		}
-		break
 	case DatabaseItemNotFound:
 		formattedErr = errors.New(err.Message)
-		break
 	default:
 		logger.Error("Error not handled", map[string]interface{}{
 			"type":  fmt.Sprintf("%T", err),

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -27,15 +27,15 @@ import (
 func GetErrorMessage(ctx context.Context, err error) error {
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	var formattedErr error
-	switch err.(type) {
+	switch err := err.(type) {
 	case *elastic.Error:
-		formattedErr = getElasticSearchErrorMessage(ctx, err.(*elastic.Error))
+		formattedErr = getElasticSearchErrorMessage(ctx, err)
 	case *json.InvalidUnmarshalError, *json.UnmarshalTypeError, *json.SyntaxError:
 		formattedErr = getJsonErrorMessage(ctx, err)
 	case *DatabaseError:
-		formattedErr = getDatabaseErrorMessage(ctx, err.(*DatabaseError))
+		formattedErr = getDatabaseErrorMessage(ctx, err)
 	case *SharedAccountError:
-		formattedErr = getSharedAccountErrorMessage(ctx, err.(*SharedAccountError))
+		formattedErr = getSharedAccountErrorMessage(ctx, err)
 	default:
 		logger.Error("Error not handled", map[string]interface{}{
 			"type":  fmt.Sprintf("%T", err),

--- a/es/accountsSharing.go
+++ b/es/accountsSharing.go
@@ -96,7 +96,7 @@ func getAllAccountsAndIndexes(user users.User, tx *sql.Tx, indexPrefix string) (
 	return accountsAndIndexes, http.StatusOK, nil
 }
 
-// GetAccountsAndIndexesreturns an AccountsAndIndexes struct, a status code and an error
+// GetAccountsAndIndexes returns an AccountsAndIndexes struct, a status code and an error
 // if the accountList parameter is empty the function will call getAllAccountsAndIndexes
 // if the accountList parameter is not empty the function will validate the accounts and
 // find their indexes

--- a/es/awsClientSigner.go
+++ b/es/awsClientSigner.go
@@ -87,7 +87,7 @@ func NewSignedHttpClientForElasticSearch(endpoint string, creds *credentials.Cre
 	return NewSignedHttpClient(creds, region, "es")
 }
 
-// NewSignedHttpCilent returns an http.Client which signs its requests with AWS
+// NewSignedHttpClient returns an http.Client which signs its requests with AWS
 // v4 signatures for the provided service name and region.
 func NewSignedHttpClient(creds *credentials.Credentials, region, service string) (*http.Client, error) {
 	signer := v4.NewSigner(creds)

--- a/es/billingRepository.go
+++ b/es/billingRepository.go
@@ -20,7 +20,7 @@ import (
 	"github.com/olivere/elastic"
 )
 
-// CleanBillByBillRepositoryId removes every bills information of a specific bill repository
+// CleanByBillRepositoryId removes every bills information of a specific bill repository
 func CleanByBillRepositoryId(ctx context.Context, aaUId, brId int) error {
 	index := IndexNameForUserId(aaUId, IndexPrefixLineItems)
 	query := elastic.NewBoolQuery()

--- a/models/awsaccountstatus.go
+++ b/models/awsaccountstatus.go
@@ -34,7 +34,7 @@ func GetLatestAccountsBillRepositoriesStatus(db XODB, billRepositoriesIds []int)
 
 	// run query
 	XOLog(sqlstr, formattedIds)
-	accounts := make(map[int]AwsAccountStatus, 0)
+	accounts := make(map[int]AwsAccountStatus)
 
 	q, err := db.Query(sqlstr, formattedIds)
 	if err != nil {

--- a/onDemandToRI/ec2/es_request_constructor.go
+++ b/onDemandToRI/ec2/es_request_constructor.go
@@ -40,7 +40,7 @@ type (
 		DateEnd     time.Time
 	}
 
-	// Structure that allow to parse ES response for RI EC2 reports
+	// ResponseRiEc2Reports allows us to parse ES response for RI EC2 reports
 	ResponseRiEc2Reports struct {
 		Accounts struct {
 			Buckets []struct {

--- a/onDemandToRI/ec2/report.go
+++ b/onDemandToRI/ec2/report.go
@@ -99,7 +99,7 @@ type (
 func addUnreservedInstance(unreservedInstances []InstancesSpecs, instanceReport ec2.InstanceReport) []InstancesSpecs {
 	for i, unreservedInstance := range unreservedInstances {
 		if instanceMatchSpecs(instanceReport, unreservedInstance) {
-			unreservedInstances[i].InstanceCount += 1
+			unreservedInstances[i].InstanceCount++
 			return unreservedInstances
 		}
 	}

--- a/plugins/account/networkEc2/networkEc2.go
+++ b/plugins/account/networkEc2/networkEc2.go
@@ -59,10 +59,10 @@ func getUnusedEc2Recommendation(pluginRes *core.PluginResult, instances []ec2.In
 		if instance.Instance.Stats.Network.In == -1 || instance.Instance.Stats.Network.Out == -1 {
 			continue
 		}
-		pluginRes.Checked += 1
+		pluginRes.Checked++
 		network := instance.Instance.Stats.Network.In + instance.Instance.Stats.Network.Out
 		if network > networkLimit {
-			pluginRes.Passed += 1
+			pluginRes.Passed++
 		} else {
 			pluginRes.Details = append(pluginRes.Details, fmt.Sprintf("%s %s", instance.Instance.Id, instance.Instance.Tags["Name"]))
 		}

--- a/plugins/account/s3Traffic/s3Traffic.go
+++ b/plugins/account/s3Traffic/s3Traffic.go
@@ -49,10 +49,10 @@ func prepareResult(pluginRes *core.PluginResult) {
 
 // getBucketsWithNoTraffic searches for buckets with no traffic and fills the pluginRes struct
 func getBucketsWithNoTraffic(pluginRes *core.PluginResult, storage, bandwidth bucketsInfos) {
-	for bucketName, _ := range storage {
-		pluginRes.Checked += 1
+	for bucketName := range storage {
+		pluginRes.Checked++
 		if _, ok := bandwidth[bucketName]; ok {
-			pluginRes.Passed += 1
+			pluginRes.Passed++
 		} else {
 			pluginRes.Details = append(pluginRes.Details, bucketName)
 		}

--- a/plugins/account/unattachedEIP/unattachedEIP.go
+++ b/plugins/account/unattachedEIP/unattachedEIP.go
@@ -51,9 +51,9 @@ func prepareResult(pluginRes *core.PluginResult) {
 func processEIP(pluginRes *core.PluginResult, region *string, eipRes *ec2.DescribeAddressesOutput) {
 	if eipRes.Addresses != nil {
 		for _, eip := range eipRes.Addresses {
-			pluginRes.Checked += 1
+			pluginRes.Checked++
 			if eip.AssociationId != nil {
-				pluginRes.Passed += 1
+				pluginRes.Passed++
 			} else {
 				eipDesc := aws.StringValue(eip.PublicIp)
 				if eipDesc == "" {

--- a/plugins/account/unusedEBS/unusedEBS.go
+++ b/plugins/account/unusedEBS/unusedEBS.go
@@ -69,11 +69,11 @@ func getUnusedEBsRecommendation(pluginParams core.PluginParams, pluginRes *core.
 		err = svc.DescribeVolumesPages(&ec2.DescribeVolumesInput{},
 			func(page *ec2.DescribeVolumesOutput, lastPage bool) bool {
 				for _, volume := range page.Volumes {
-					pluginRes.Checked += 1
+					pluginRes.Checked++
 					if volume != nil && *volume.State == "available" {
 						unusedByAZ[*volume.AvailabilityZone] = unusedByAZ[*volume.AvailabilityZone] + 1
 					} else {
-						pluginRes.Passed += 1
+						pluginRes.Passed++
 					}
 				}
 				return lastPage

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -15,6 +15,7 @@
 package plugins
 
 import (
+	// This is solely for the side effects of importation, i.e. registration of the plugins
 	_ "github.com/trackit/trackit/plugins/account/networkEc2"
 	_ "github.com/trackit/trackit/plugins/account/s3Traffic"
 	_ "github.com/trackit/trackit/plugins/account/unattachedEIP"

--- a/reports/module_cost_variation.go
+++ b/reports/module_cost_variation.go
@@ -217,7 +217,6 @@ func costVariationGenerateHeader(file *excelize.File, sheetName string, dates []
 		newColumnWidth(totalCol, 15),
 	}
 	columns.setValues(file, sheetName)
-	return
 }
 
 func costVariationFormatCostDiff(data []diff.PricePoint) (values costVariationProduct, err error) {

--- a/reports/module_ebs_usage_report.go
+++ b/reports/module_ebs_usage_report.go
@@ -133,5 +133,4 @@ func ebsUsageReportGenerateHeader(file *excelize.File) {
 		newColumnWidth("H", 30),
 	}
 	columns.setValues(file, ebsUsageReportSheetName)
-	return
 }

--- a/reports/module_ec2_usage_report.go
+++ b/reports/module_ec2_usage_report.go
@@ -164,7 +164,6 @@ func ec2UsageReportGenerateHeader(file *excelize.File) {
 		newColumnWidth("O", 30),
 	}
 	columns.setValues(file, ec2UsageReportSheetName)
-	return
 }
 
 func ec2SizingRecommendationInsertData(file *excelize.File, instance ec2.Instance, name, formattedAccount string, line int) {
@@ -203,5 +202,4 @@ func ec2SizingRecommendationsHeader(file *excelize.File) {
 		newColumnWidth("H", 35),
 	}
 	columns.setValues(file, ec2SizingRecommendationsSheetName)
-	return
 }

--- a/reports/module_elasticache_usage_report.go
+++ b/reports/module_elasticache_usage_report.go
@@ -150,5 +150,4 @@ func elastiCacheUsageReportGenerateHeader(file *excelize.File) {
 		newColumnWidth("L", 30),
 	}
 	columns.setValues(file, elastiCacheUsageReportSheetName)
-	return
 }

--- a/reports/module_es_usage_report.go
+++ b/reports/module_es_usage_report.go
@@ -163,5 +163,4 @@ func esUsageReportGenerateHeader(file *excelize.File) {
 		newColumnWidth("N", 30),
 	}
 	columns.setValues(file, esUsageReportSheetName)
-	return
 }

--- a/reports/module_lambda_usage_report.go
+++ b/reports/module_lambda_usage_report.go
@@ -149,5 +149,4 @@ func lambdaUsageReportGenerateHeader(file *excelize.File) {
 		newColumnWidth("L", 30),
 	}
 	columns.setValues(file, lambdaUsageReportSheetName)
-	return
 }

--- a/reports/module_rds_usage_report.go
+++ b/reports/module_rds_usage_report.go
@@ -148,5 +148,4 @@ func rdsUsageReportGenerateHeader(file *excelize.File) {
 		newColumnWidth("L", 12.5).toColumn("M"),
 	}
 	columns.setValues(file, rdsUsageReportSheetName)
-	return
 }

--- a/reports/module_ri_ec2_usage_report.go
+++ b/reports/module_ri_ec2_usage_report.go
@@ -151,5 +151,4 @@ func riEc2ReportGenerateHeader(file *excelize.File) {
 		newColumnWidth("L", 15).toColumn("M"),
 	}
 	columns.setValues(file, riEc2ReportSheetName)
-	return
 }

--- a/reports/module_s3_cost_report.go
+++ b/reports/module_s3_cost_report.go
@@ -134,5 +134,4 @@ func s3CostReportGenerateHeader(file *excelize.File) {
 		newColumnWidth("H", 20).toColumn("I"),
 	}
 	columns.setValues(file, s3CostReportSheetName)
-	return
 }

--- a/reports/module_tags_report.go
+++ b/reports/module_tags_report.go
@@ -206,7 +206,6 @@ func tagsUsageReportGenerateHeader(file *excelize.File, key string) {
 		newColumnWidth("H", 30),
 	}
 	columns.setValues(file, key)
-	return
 }
 
 func generateLinearChart(ctx context.Context, file *excelize.File, sheetName, data string) error {

--- a/reports/spreadsheet_cell.go
+++ b/reports/spreadsheet_cell.go
@@ -55,9 +55,7 @@ func (c cell) mergeTo(merge string) cell {
 }
 
 func (c cell) addStyles(styles ...string) cell {
-	for _, style := range styles {
-		c.styles = append(c.styles, style)
-	}
+	c.styles = append(c.styles, styles...)
 	return c
 }
 

--- a/reports/spreadsheet_conditional_formatting.go
+++ b/reports/spreadsheet_conditional_formatting.go
@@ -15,7 +15,6 @@
 package reports
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -63,7 +62,7 @@ func (c conditionalFormat) getConditionalFormatting(file *excelize.File) (string
 	if !c.custom {
 		value, ok := conditionsRaw[c.value]
 		if !ok {
-			return "", errors.New(fmt.Sprintf("Condition %s not found", c.value))
+			return "", fmt.Errorf("Condition %s not found", c.value)
 		}
 		condition = value
 	}

--- a/routes/decoratorCors.go
+++ b/routes/decoratorCors.go
@@ -46,7 +46,7 @@ func (c Cors) Decorate(h Handler) Handler {
 }
 
 // getFunc builds a handler function for Cors.Decorate.
-func (_ Cors) getFunc(
+func (Cors) getFunc(
 	hf HandlerFunc,
 	hd HandlerDocumentation,
 	acaMethods []string,

--- a/routes/decoratorErrorBody.go
+++ b/routes/decoratorErrorBody.go
@@ -33,7 +33,7 @@ func (d ErrorBody) Decorate(h Handler) Handler {
 }
 
 // getFunc builds the handler function for ErrorBody.Decorate.
-func (_ ErrorBody) getFunc(hf HandlerFunc) HandlerFunc {
+func (ErrorBody) getFunc(hf HandlerFunc) HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request, a Arguments) (int, interface{}) {
 		status, output := hf(w, r, a)
 		if err, ok := output.(error); ok {

--- a/routes/decoratorPanicAsError.go
+++ b/routes/decoratorPanicAsError.go
@@ -32,7 +32,7 @@ func (d PanicAsError) Decorate(h Handler) Handler {
 }
 
 // getFunc builds the handler function for PanicAsError.Decorate.
-func (_ PanicAsError) getFunc(hf HandlerFunc) HandlerFunc {
+func (PanicAsError) getFunc(hf HandlerFunc) HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request, a Arguments) (status int, output interface{}) {
 		defer func() {
 			if rc := recover(); rc != nil {

--- a/routes/decoratorQueryArgs.go
+++ b/routes/decoratorQueryArgs.go
@@ -174,12 +174,7 @@ func (QueryArgUintSlice) QueryParse(val string) (interface{}, error) {
 // QueryParse parses a []string. Since it does not do any type conversion,
 // it cannot fail. With this func, QueryArgStringSlice fulfills QueryArgType.
 func (QueryArgStringSlice) QueryParse(val string) (interface{}, error) {
-	vals := strings.Split(val, ",")
-	res := make([]string, 0, len(vals))
-	for _, v := range vals {
-		res = append(res, v)
-	}
-	return res, nil
+	return strings.Split(val, ","), nil
 }
 
 // QueryParse parses a time.Time in the ISO8601 format. With this func,

--- a/routes/decoratorRequestId.go
+++ b/routes/decoratorRequestId.go
@@ -31,7 +31,7 @@ func (ri RequestId) Decorate(h Handler) Handler {
 }
 
 // getFunc builds the handler function for RequestId.Decorate
-func (_ RequestId) getFunc(hf HandlerFunc) HandlerFunc {
+func (RequestId) getFunc(hf HandlerFunc) HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request, a Arguments) (int, interface{}) {
 		requestId := uuid.NewV1().String()
 		r = requestWithLoggedContextValue(r, contextKeyRequestId, "requestId", requestId)

--- a/routes/decoratorRouteLog.go
+++ b/routes/decoratorRouteLog.go
@@ -51,7 +51,7 @@ func (rl RouteLog) Decorate(h Handler) Handler {
 }
 
 // getFunc builds the route handler function for RouteLog.Decorate.
-func (_ RouteLog) getFunc(hf HandlerFunc) HandlerFunc {
+func (RouteLog) getFunc(hf HandlerFunc) HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request, a Arguments) (status int, response interface{}) {
 		l := jsonlog.LoggerFromContextOrDefault(r.Context())
 		rqd := getRequestLogData(r)
@@ -92,7 +92,7 @@ func getRequestLogData(r *http.Request) requestLogData {
 // getResponseLogData fills a responseLogData instance with information about
 // how a request was handled.
 func getResponseLogData(rqd requestLogData, status int, response interface{}) (rsd responseLogData) {
-	rsd.Nanoseconds = time.Now().Sub(rqd.Time)
+	rsd.Nanoseconds = time.Since(rqd.Time)
 	rsd.Status = status
 	return
 }

--- a/routes/simpleHandler.go
+++ b/routes/simpleHandler.go
@@ -18,7 +18,7 @@ import (
 	"net/http"
 )
 
-// Handler is the type a route Handler must have.
+// SimpleHandler is the type a route handler must have.
 type SimpleHandler func(*http.Request, Arguments) (int, interface{})
 
 // H builds a Handler from a SimpleHandler. The produced handler has an empty

--- a/s3/costs/prepare_response.go
+++ b/s3/costs/prepare_response.go
@@ -108,7 +108,7 @@ func parseBuckets(buckets BucketsInfo, parsedDocument bucket, resultType string)
 		if isValidBucket(bucketName) {
 			bucketInfo := getBucketInfoByName(buckets, bucketName)
 			if resultTypePtr, ok := resultTypeToBucketCostGetter[resultType]; ok {
-				bucketInfo = resultTypePtr(bucketInfo, bucketData)
+				resultTypePtr(bucketInfo, bucketData)
 			}
 		}
 	}

--- a/s3/costs/prepare_response.go
+++ b/s3/costs/prepare_response.go
@@ -106,9 +106,8 @@ func parseBuckets(buckets BucketsInfo, parsedDocument bucket, resultType string)
 		bucketName := bucketData["key"].(string)
 		// The billing data can contain billings for errored requests that we do not want to see
 		if isValidBucket(bucketName) {
-			bucketInfo := getBucketInfoByName(buckets, bucketName)
 			if resultTypePtr, ok := resultTypeToBucketCostGetter[resultType]; ok {
-				resultTypePtr(bucketInfo, bucketData)
+				resultTypePtr(getBucketInfoByName(buckets, bucketName), bucketData)
 			}
 		}
 	}

--- a/server/taskProcessAccount.go
+++ b/server/taskProcessAccount.go
@@ -305,7 +305,7 @@ func processAccountS3(ctx context.Context, aa aws.AwsAccount) error {
 	return err
 }
 
-// processAccountCloudFormation processes all the S3 data for an AwsAccount
+// processAccountCloudFormation processes all the CloudFormation data for an AwsAccount
 func processAccountCloudFormation(ctx context.Context, aa aws.AwsAccount) error {
 	err := cloudformation.FetchDailyCloudFormationStats(ctx, aa)
 	if err != nil {
@@ -357,7 +357,7 @@ func processAccountES(ctx context.Context, aa aws.AwsAccount) error {
 	return err
 }
 
-// processAccountRoute53 processes all the StepFunctions data for an AwsAccount
+// processAccountRoute53 processes all the Route53 data for an AwsAccount
 func processAccountRoute53(ctx context.Context, aa aws.AwsAccount) error {
 	err := route53.FetchDailyRoute53Stats(ctx, aa)
 	if err != nil {

--- a/server/taskUpdateTags.go
+++ b/server/taskUpdateTags.go
@@ -86,7 +86,8 @@ func updateTagsForUser(ctx context.Context, userId int) (err error) {
 	if job, err = registerUpdateTagsTask(db.Db, userId); err != nil {
 	} else if err = tagging.UpdateTagsForUser(ctx, userId); err != nil {
 	} else if err = tagging.UpdateMostUsedTagsForUser(ctx, userId); err != nil {
-	} else if err = tagging.UpdateTaggingComplianceForUser(ctx, userId); err != nil {
+	} else {
+		err = tagging.UpdateTaggingComplianceForUser(ctx, userId)
 	}
 	updateUpdateTagsTask(db.Db, job, err)
 	if err != nil {

--- a/server/taskWorker.go
+++ b/server/taskWorker.go
@@ -87,6 +87,7 @@ func taskWorker(ctx context.Context) error {
 			continue
 		}
 
+		// TODO: Perhaps should avoid using built-in string type as key, so as to avoid collisions
 		ctx = context.WithValue(ctx, "taskParameters", message.Parameters)
 
 		if task, ok := tasks[message.TaskName]; ok {

--- a/tagging/elasticache/process.go
+++ b/tagging/elasticache/process.go
@@ -17,7 +17,6 @@ package tagginges
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/olivere/elastic"
 	"github.com/trackit/jsonlog"
@@ -75,7 +74,7 @@ func processHit(ctx context.Context, hit *elastic.SearchHit, resourceTypeString 
 		ResourceID:   source.Instance.Id,
 		ResourceType: resourceTypeString,
 		Region:       source.Instance.Region,
-		URL:          fmt.Sprintf(urlFormat),
+		URL:          urlFormat,
 		Tags:         source.Instance.Tags,
 	}
 	return document, true

--- a/tagging/routes/prepareResponse.go
+++ b/tagging/routes/prepareResponse.go
@@ -27,7 +27,7 @@ import (
 
 type (
 
-	// Structure that allow to parse ES response for resources tagging
+	// ResponseResources allows us to parse an ES response for resources tagging
 	ResponseResources struct {
 		Accounts struct {
 			Buckets []struct {

--- a/tagging/routes/routeGetShouldPopup.go
+++ b/tagging/routes/routeGetShouldPopup.go
@@ -79,11 +79,7 @@ func checkPopup(dbUser *models.TagbotUser, customer *models.User) (int, interfac
 	}
 }
 
+// checkUserTagbotFreeTrial returns whether the time since the creation date exceeds the duration of a TagBot free trial
 func checkUserTagbotFreeTrial(creationDate time.Time) bool {
-	currentTime := time.Now()
-	timeSinceCreation := currentTime.Sub(creationDate)
-	if timeSinceCreation > tagbotFreeTrialDuration {
-		return false
-	}
-	return true
+	return time.Since(creationDate) <= tagbotFreeTrialDuration
 }

--- a/unusedAccounts/checkUnusedAccounts.go
+++ b/unusedAccounts/checkUnusedAccounts.go
@@ -35,7 +35,7 @@ func CheckUnusedAccounts(ctx context.Context) error {
 }
 
 func checkUnusedAccount(ctx context.Context, user models.User) error {
-	unusedTime := time.Now().Sub(user.LastSeen)
+	unusedTime := time.Since(user.LastSeen)
 
 	thresholdStage := 0
 	for i, reminderThreshold := range remindersThresholds {
@@ -49,7 +49,7 @@ func checkUnusedAccount(ctx context.Context, user models.User) error {
 	var err error = nil
 
 	if user.LastUnusedReminder.Sub(user.LastSeen) < remindersThresholds[thresholdStage] {
-		timeBeforeDeletion := user.LastSeen.Add(deleteThreshold).Sub(time.Now())
+		timeBeforeDeletion := time.Until(user.LastSeen.Add(deleteThreshold))
 		err = sendReminder(ctx, user, timeBeforeDeletion)
 
 		user.LastUnusedReminder = time.Now()

--- a/usageReports/ebs/get_ebs_data.go
+++ b/usageReports/ebs/get_ebs_data.go
@@ -116,7 +116,7 @@ func GetEbsData(ctx context.Context, parsedParams EbsQueryParams, user users.Use
 	returnCode, monthlySnapshots, err := GetEbsMonthlySnapshots(ctx, parsedParams)
 	if err != nil {
 		return returnCode, nil, err
-	} else if monthlySnapshots != nil && len(monthlySnapshots) > 0 {
+	} else if len(monthlySnapshots) > 0 { // Note: len(nil) is 0
 		return returnCode, monthlySnapshots, nil
 	}
 	returnCode, dailySnapshots, err := GetEbsDailySnapshots(ctx, parsedParams, user, tx)

--- a/usageReports/ebs/prepare_response.go
+++ b/usageReports/ebs/prepare_response.go
@@ -28,7 +28,7 @@ import (
 
 type (
 
-	// Structure that allow to parse ES response for costs
+	// ResponseCost allows us to parse an ES response for costs
 	ResponseCost struct {
 		Accounts struct {
 			Buckets []struct {
@@ -45,7 +45,7 @@ type (
 		} `json:"accounts"`
 	}
 
-	// Structure that allow to parse ES response for EBS Monthly snapshots
+	// ResponseEbsMonthly allows us to parse an ES response for EBS Monthly snapshots
 	ResponseEbsMonthly struct {
 		Accounts struct {
 			Buckets []struct {
@@ -60,7 +60,7 @@ type (
 		} `json:"accounts"`
 	}
 
-	// Structure that allow to parse ES response for EBS Daily snapshots
+	// ResponseEbsDaily allows us to parse an ES response for EBS Daily snapshots
 	ResponseEbsDaily struct {
 		Accounts struct {
 			Buckets []struct {
@@ -102,7 +102,7 @@ type (
 )
 
 func getEbsSnapshotReportResponse(oldSnapshot ebs.SnapshotReport) SnapshotReport {
-	tags := make(map[string]string, 0)
+	tags := make(map[string]string, len(oldSnapshot.Snapshot.Tags))
 	for _, tag := range oldSnapshot.Snapshot.Tags {
 		tags[tag.Key] = tag.Value
 	}

--- a/usageReports/ec2/get_ec2_data.go
+++ b/usageReports/ec2/get_ec2_data.go
@@ -116,7 +116,7 @@ func GetEc2Data(ctx context.Context, parsedParams Ec2QueryParams, user users.Use
 	returnCode, monthlyInstances, err := GetEc2MonthlyInstances(ctx, parsedParams)
 	if err != nil {
 		return returnCode, nil, err
-	} else if monthlyInstances != nil && len(monthlyInstances) > 0 {
+	} else if len(monthlyInstances) > 0 { // Note: len(nil) is 0
 		return returnCode, monthlyInstances, nil
 	}
 	returnCode, dailyInstances, err := GetEc2DailyInstances(ctx, parsedParams, user, tx)

--- a/usageReports/ec2/prepare_response.go
+++ b/usageReports/ec2/prepare_response.go
@@ -31,7 +31,7 @@ import (
 
 type (
 
-	// Structure that allow to parse ES response for costs
+	// ResponseCost allows us to parse an ES response for costs
 	ResponseCost struct {
 		Accounts struct {
 			Buckets []struct {
@@ -48,7 +48,7 @@ type (
 		} `json:"accounts"`
 	}
 
-	// Structure that allow to parse ES response for EC2 Monthly instances
+	// ResponseEc2Monthly allows us to parse an ES response for EC2 Monthly instances
 	ResponseEc2Monthly struct {
 		Accounts struct {
 			Buckets []struct {
@@ -63,7 +63,7 @@ type (
 		} `json:"accounts"`
 	}
 
-	// Structure that allow to parse ES response for EC2 Daily instances
+	// ResponseEc2Daily allows us to parse an ES response for EC2 Daily instances
 	ResponseEc2Daily struct {
 		Accounts struct {
 			Buckets []struct {
@@ -112,7 +112,7 @@ type (
 		Volumes Volumes     `json:"volumes"`
 	}
 
-	// Volume contains information about EBS volumes
+	// Volumes contains information about EBS volumes
 	Volumes struct {
 		Read  map[string]float64 `json:"read"`
 		Write map[string]float64 `json:"write"`
@@ -120,12 +120,12 @@ type (
 )
 
 func getEc2InstanceReportResponse(oldInstance ec2.InstanceReport) InstanceReport {
-	tags := make(map[string]string, 0)
+	tags := make(map[string]string, len(oldInstance.Instance.Tags))
 	for _, tag := range oldInstance.Instance.Tags {
 		tags[tag.Key] = tag.Value
 	}
-	read := make(map[string]float64, 0)
-	write := make(map[string]float64, 0)
+	read := make(map[string]float64, len(oldInstance.Instance.Stats.Volumes))
+	write := make(map[string]float64, len(oldInstance.Instance.Stats.Volumes))
 	for _, volume := range oldInstance.Instance.Stats.Volumes {
 		read[volume.Id] = volume.Read
 		write[volume.Id] = volume.Write
@@ -157,7 +157,7 @@ func getEc2InstanceReportResponse(oldInstance ec2.InstanceReport) InstanceReport
 // addCostToInstance adds a cost for an instance based on billing data
 func addCostToInstance(instance ec2.InstanceReport, costs ResponseCost) ec2.InstanceReport {
 	if instance.Instance.Costs == nil {
-		instance.Instance.Costs = make(map[string]float64, 0)
+		instance.Instance.Costs = make(map[string]float64)
 	}
 	for _, accounts := range costs.Accounts.Buckets {
 		if accounts.Key != instance.Account {

--- a/usageReports/ec2Coverage/prepare_response.go
+++ b/usageReports/ec2Coverage/prepare_response.go
@@ -27,7 +27,7 @@ import (
 )
 
 type (
-	// Structure that allow to parse ES response for EC2 Coverage Monthly report
+	// ResponseEc2CoverageMonthly allows us to parse an ES response for EC2 Coverage Monthly report
 	ResponseEc2CoverageMonthly struct {
 		Accounts struct {
 			Buckets []struct {

--- a/usageReports/elasticache/get_elasticache_data.go
+++ b/usageReports/elasticache/get_elasticache_data.go
@@ -116,7 +116,7 @@ func GetElastiCacheData(ctx context.Context, parsedParams ElastiCacheQueryParams
 	returnCode, monthlyInstances, err := GetElastiCacheMonthlyInstances(ctx, parsedParams)
 	if err != nil {
 		return returnCode, nil, err
-	} else if monthlyInstances != nil && len(monthlyInstances) > 0 {
+	} else if len(monthlyInstances) > 0 { // Note: len(nil) is 0
 		return returnCode, monthlyInstances, nil
 	}
 	returnCode, dailyInstances, err := GetElastiCacheDailyInstances(ctx, parsedParams, user, tx)

--- a/usageReports/elasticache/prepare_response.go
+++ b/usageReports/elasticache/prepare_response.go
@@ -31,7 +31,7 @@ import (
 
 type (
 
-	// Structure that allow to parse ES response for costs
+	// ResponseCost allows us to parse an ES response for costs
 	ResponseCost struct {
 		Accounts struct {
 			Buckets []struct {
@@ -48,7 +48,7 @@ type (
 		} `json:"accounts"`
 	}
 
-	// Structure that allow to parse ES response for ElastiCache Monthly instances
+	// ResponseElastiCacheMonthly allows us to parse an ES response for ElastiCache Monthly instances
 	ResponseElastiCacheMonthly struct {
 		Accounts struct {
 			Buckets []struct {
@@ -63,7 +63,7 @@ type (
 		} `json:"accounts"`
 	}
 
-	// Structure that allow to parse ES response for ElastiCache Daily instances
+	// ResponseElastiCacheDaily allows us to parse an ES response for ElastiCache Daily instances
 	ResponseElastiCacheDaily struct {
 		Accounts struct {
 			Buckets []struct {
@@ -99,7 +99,7 @@ type (
 )
 
 func getElastiCacheInstanceReportResponse(oldInstance elasticache.InstanceReport) InstanceReport {
-	tags := make(map[string]string, 0)
+	tags := make(map[string]string, len(oldInstance.Instance.Tags))
 	for _, tag := range oldInstance.Instance.Tags {
 		tags[tag.Key] = tag.Value
 	}
@@ -118,7 +118,7 @@ func getElastiCacheInstanceReportResponse(oldInstance elasticache.InstanceReport
 // addCostToInstance adds a cost for an instance based on billing data
 func addCostToInstance(instance elasticache.InstanceReport, costs ResponseCost) elasticache.InstanceReport {
 	if instance.Instance.Costs == nil {
-		instance.Instance.Costs = make(map[string]float64, 0)
+		instance.Instance.Costs = make(map[string]float64)
 	}
 	for _, accounts := range costs.Accounts.Buckets {
 		if accounts.Key != instance.Account {

--- a/usageReports/es/es_route.go
+++ b/usageReports/es/es_route.go
@@ -33,7 +33,7 @@ type (
 		Date        time.Time
 	}
 
-	// Ec2UnusedQueryParams will store the parsed query params
+	// EsUnusedQueryParams will store the parsed query params
 	EsUnusedQueryParams struct {
 		AccountList []string
 		IndexList   []string

--- a/usageReports/es/get_es_data.go
+++ b/usageReports/es/get_es_data.go
@@ -116,7 +116,7 @@ func GetEsData(ctx context.Context, parsedParams EsQueryParams, user users.User,
 	returnCode, monthlyDomains, err := GetEsMonthlyDomains(ctx, parsedParams)
 	if err != nil {
 		return returnCode, nil, err
-	} else if monthlyDomains != nil && len(monthlyDomains) > 0 {
+	} else if len(monthlyDomains) > 0 { // Note: len(nil) is 0
 		return returnCode, monthlyDomains, nil
 	}
 	returnCode, dailyDomains, err := GetEsDailyDomains(ctx, parsedParams, user, tx)

--- a/usageReports/es/prepare_response.go
+++ b/usageReports/es/prepare_response.go
@@ -30,7 +30,7 @@ import (
 
 type (
 
-	// Structure that allow to parse ES response for costs
+	// ResponseCost allows us to parse an ES response for costs
 	ResponseCost struct {
 		Accounts struct {
 			Buckets []struct {
@@ -47,7 +47,7 @@ type (
 		} `json:"accounts"`
 	}
 
-	// Structure that allow to parse ES response for ES monthly domains
+	// ResponseEsMonthly allows us to parse an ES response for ES monthly domains
 	ResponseEsMonthly struct {
 		Accounts struct {
 			Buckets []struct {
@@ -62,7 +62,7 @@ type (
 		} `json:"accounts"`
 	}
 
-	// Structure that allow to parse ES response for ES daily domains
+	// ResponseEsDaily allows us to parse an ES response for ES daily domains
 	ResponseEsDaily struct {
 		Accounts struct {
 			Buckets []struct {
@@ -98,7 +98,7 @@ type (
 )
 
 func getEsDomainReportResponse(oldDomain es.DomainReport) DomainReport {
-	tags := make(map[string]string, 0)
+	tags := make(map[string]string)
 	for _, tag := range oldDomain.Domain.Tags {
 		tags[tag.Key] = tag.Value
 	}
@@ -116,7 +116,7 @@ func getEsDomainReportResponse(oldDomain es.DomainReport) DomainReport {
 
 // addCostToDomain adds cost for each domain based on billing data
 func addCostToDomain(domain es.DomainReport, costs ResponseCost) es.DomainReport {
-	domain.Domain.Costs = make(map[string]float64, 0)
+	domain.Domain.Costs = make(map[string]float64, 1)
 	for _, accounts := range costs.Accounts.Buckets {
 		if accounts.Key != domain.Account {
 			continue

--- a/usageReports/instanceCount/prepare_response.go
+++ b/usageReports/instanceCount/prepare_response.go
@@ -29,7 +29,7 @@ import (
 
 type (
 
-	// Structure that allow to parse ES response for costs
+	// ResponseCost allows us to parse an ES response for costs
 	ResponseCost struct {
 		Accounts struct {
 			Buckets []struct {
@@ -46,7 +46,7 @@ type (
 		} `json:"accounts"`
 	}
 
-	// Structure that allow to parse ES response for InstanceCount Monthly
+	// ResponseInstanceCountMonthly allows us to parse an ES response for InstanceCount Monthly
 	ResponseInstanceCountMonthly struct {
 		Accounts struct {
 			Buckets []struct {
@@ -61,7 +61,7 @@ type (
 		} `json:"accounts"`
 	}
 
-	// Structure that allow to parse ES response for InstanceCount Daily
+	// ResponseInstanceCountDaily allows us to parse an ES response for InstanceCount Daily
 	ResponseInstanceCountDaily struct {
 		Accounts struct {
 			Buckets []struct {
@@ -81,7 +81,7 @@ type (
 		} `json:"accounts"`
 	}
 
-	// InstanceCount is saved in ES to have all the information of an InstanceCount
+	// InstanceCountReport is saved in ES to have all the information of an InstanceCount
 	InstanceCountReport struct {
 		utils.ReportBase
 		InstanceCount InstanceCount `json:"instanceCount"`

--- a/usageReports/lambda/prepare_response.go
+++ b/usageReports/lambda/prepare_response.go
@@ -26,7 +26,7 @@ import (
 )
 
 type (
-	// Structure that allow to parse ES response for Lambda Daily functions
+	// ResponseLambdaDaily allows us to parse an ES response for Lambda Daily functions
 	ResponseLambdaDaily struct {
 		Accounts struct {
 			Buckets []struct {
@@ -61,7 +61,7 @@ type (
 )
 
 func getLambdaFunctionReportResponse(oldFunction lambda.FunctionReport) FunctionReport {
-	tags := make(map[string]string, 0)
+	tags := make(map[string]string, len(oldFunction.Function.Tags))
 	for _, tag := range oldFunction.Function.Tags {
 		tags[tag.Key] = tag.Value
 	}

--- a/usageReports/rds/get_rds_data.go
+++ b/usageReports/rds/get_rds_data.go
@@ -116,7 +116,7 @@ func GetRdsData(ctx context.Context, parsedParams RdsQueryParams, user users.Use
 	returnCode, monthlyInstances, err := GetRdsMonthlyInstances(ctx, parsedParams)
 	if err != nil {
 		return returnCode, nil, err
-	} else if monthlyInstances != nil && len(monthlyInstances) > 0 {
+	} else if len(monthlyInstances) > 0 { // Note: len(nil) is 0
 		return returnCode, monthlyInstances, nil
 	}
 	returnCode, dailyInstances, err := GetRdsDailyInstances(ctx, parsedParams, user, tx)

--- a/usageReports/rds/prepare_response.go
+++ b/usageReports/rds/prepare_response.go
@@ -31,7 +31,7 @@ import (
 
 type (
 
-	// Structure that allow to parse ES response for costs
+	// ResponseCost allows us to parse an ES response for costs
 	ResponseCost struct {
 		Accounts struct {
 			Buckets []struct {
@@ -48,7 +48,7 @@ type (
 		} `json:"accounts"`
 	}
 
-	// Structure that allow to parse ES response for RDS Monthly instances
+	// ResponseRdsMonthly allows us to parse an ES response for RDS Monthly instances
 	ResponseRdsMonthly struct {
 		Accounts struct {
 			Buckets []struct {
@@ -63,7 +63,7 @@ type (
 		} `json:"accounts"`
 	}
 
-	// Structure that allow to parse ES response for RDS Daily instances
+	// ResponseRdsDaily to parse an ES response for RDS Daily instances
 	ResponseRdsDaily struct {
 		Accounts struct {
 			Buckets []struct {
@@ -118,7 +118,7 @@ func getRdsInstanceReportResponse(oldInstance rds.InstanceReport) InstanceReport
 // addCostToInstance adds cost for an instance based on billing data
 func addCostToInstance(instance rds.InstanceReport, costs ResponseCost) rds.InstanceReport {
 	if instance.Instance.Costs == nil {
-		instance.Instance.Costs = make(map[string]float64, 0)
+		instance.Instance.Costs = make(map[string]float64, 1)
 	}
 	for _, accounts := range costs.Accounts.Buckets {
 		if accounts.Key != instance.Account {

--- a/usageReports/riEc2/prepare_response.go
+++ b/usageReports/riEc2/prepare_response.go
@@ -27,7 +27,7 @@ import (
 
 type (
 
-	// Structure that allow to parse ES response for ReservedInstances Daily reservations
+	// ResponseReservedInstancesDaily allows us to parse an ES response for ReservedInstances Daily reservations
 	ResponseReservedInstancesDaily struct {
 		Accounts struct {
 			Buckets []struct {
@@ -61,7 +61,7 @@ type (
 )
 
 func getReservedInstancesReportResponse(oldReservation riEc2.ReservationReport) ReservationReport {
-	tags := make(map[string]string, 0)
+	tags := make(map[string]string, len(oldReservation.Reservation.Tags))
 	for _, tag := range oldReservation.Reservation.Tags {
 		tags[tag.Key] = tag.Value
 	}

--- a/usageReports/riRds/prepare_response.go
+++ b/usageReports/riRds/prepare_response.go
@@ -27,7 +27,7 @@ import (
 
 type (
 
-	// Structure that allow to parse ES response for ReservedInstances Daily reservations
+	// ResponseReservedInstancesDaily allows us to parse an ES response for ReservedInstances Daily reservations
 	ResponseReservedInstancesDaily struct {
 		Accounts struct {
 			Buckets []struct {
@@ -61,7 +61,7 @@ type (
 )
 
 func getReservedInstancesReportResponse(oldReservation riRdS.InstanceReport) ReservationReport {
-	tags := make(map[string]string, 0)
+	tags := make(map[string]string, len(oldReservation.Instance.Tags))
 	for _, tag := range oldReservation.Instance.Tags {
 		tags[tag.Key] = tag.Value
 	}

--- a/users/create.go
+++ b/users/create.go
@@ -42,7 +42,7 @@ const (
 )
 
 var (
-	ErrPasswordTooShort = errors.New(fmt.Sprintf("Password must be at least %u characters.", passwordMaxLength))
+	ErrPasswordTooShort = fmt.Errorf("Password must be at least %u characters.", passwordMaxLength)
 )
 
 func init() {

--- a/users/decorator.go
+++ b/users/decorator.go
@@ -54,7 +54,7 @@ func (d RequireAuthenticatedUser) getFunc(hf routes.HandlerFunc) routes.HandlerF
 		logger := jsonlog.LoggerFromContextOrDefault(r.Context())
 		auth := r.Header["Authorization"]
 		tx := a[db.Transaction].(*sql.Tx)
-		if auth != nil && len(auth) == 1 {
+		if len(auth) == 1 {
 			tokenString := auth[0]
 			if user, err := testToken(tx, tokenString); err == nil {
 				return d.handleWithAuthenticatedUser(user, tx, hf, w, r, a)
@@ -95,7 +95,7 @@ func (d RequireAuthenticatedUser) handleWithAuthenticatedUser(user User, tx *sql
 	return hf(w, r, a)
 }
 
-func (_ RequireAuthenticatedUser) getDocumentation(hd routes.HandlerDocumentation) routes.HandlerDocumentation {
+func (RequireAuthenticatedUser) getDocumentation(hd routes.HandlerDocumentation) routes.HandlerDocumentation {
 	if hd.Tags == nil {
 		hd.Tags = make(routes.Tags)
 	}

--- a/users/password.go
+++ b/users/password.go
@@ -162,7 +162,7 @@ func resetPasswordWithValidBody(request *http.Request, body resetPasswordRequest
 		return 404, errors.New("Reset token not found")
 	}
 	err = passwordMatchesHash(body.Token, forgottenPassword.Token)
-	delta := time.Now().Sub(forgottenPassword.Created)
+	delta := time.Since(forgottenPassword.Created)
 	expired := delta.Hours() > nbHoursValidityForgottenToken
 	if err != nil || expired == true {
 		logger.Warning("Invalid token", struct {

--- a/users/shared_account/invite.go
+++ b/users/shared_account/invite.go
@@ -155,8 +155,8 @@ func sendMailNotification(ctx context.Context, tx *sql.Tx, userMail string, user
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	if userNew {
 		mailSubject := "An AWS account has been added to your Trackit account"
-		mailBody := fmt.Sprintf("%s", "Hi, a new AWS account has been added to your Trackit Account. "+
-			"You can connect to your account to manage it : https://re.trackit.io/")
+		mailBody := "Hi, a new AWS account has been added to your Trackit Account. "+
+			"You can connect to your account to manage it : https://re.trackit.io/"
 		err := mail.SendMail(userMail, mailSubject, mailBody, ctx)
 		if err != nil {
 			logger.Error("Failed to send email.", err.Error())
@@ -164,6 +164,10 @@ func sendMailNotification(ctx context.Context, tx *sql.Tx, userMail string, user
 		}
 	} else {
 		dbForgottenPassword, token, err := resetPasswordGenerator(ctx, tx, newUserId)
+		if err != nil {
+			logger.Error("Failed to create reset password token.", err.Error())
+			return err
+		}
 		mailSubject := "You are invited to join Trackit"
 		mailBody := fmt.Sprintf("Hi, you have been invited to join trackit. Please follow this link to create"+
 			" your account: https://re.trackit.io/reset/%d/%s.", dbForgottenPassword.ID, token)
@@ -216,7 +220,7 @@ func inviteNewUser(ctx context.Context, tx *sql.Tx, body InviteUserRequest, acco
 	}
 }
 
-// inviteUserWithValidBody tries to share an account with a specific user
+// InviteUserWithValidBody tries to share an account with a specific user
 func InviteUserWithValidBody(request *http.Request, body InviteUserRequest, accountId int, tx *sql.Tx, user users.User) (int, interface{}) {
 	logger := jsonlog.LoggerFromContextOrDefault(request.Context())
 	security, err := safetyCheckByAccountIdAndPermissionLevel(request.Context(), tx, accountId, body, user)

--- a/users/shared_account/routes.go
+++ b/users/shared_account/routes.go
@@ -9,7 +9,7 @@ import (
 	"github.com/trackit/trackit/users"
 )
 
-// inviteUserRequest is the expected request body for the invite user route handler.
+// InviteUserRequest is the expected request body for the invite user route handler.
 type InviteUserRequest struct {
 	Email           string `json:"email"            req:"nonzero"`
 	Origin          string `json:"origin"           req:"nonzero"`

--- a/users/shared_account/security_checks.go
+++ b/users/shared_account/security_checks.go
@@ -101,6 +101,10 @@ func safetyCheckByShareId(ctx context.Context, tx *sql.Tx, shareId int, user use
 		return false, errors.GetErrorMessage(ctx, &errors.DatabaseError{errors.DatabaseGenericError, err.Error()})
 	}
 	dbAwsAccount, err := models.AwsAccountByID(tx, dbShareAccount.AccountID)
+	if err != nil {
+		logger.Error("Error while retrieving AWS account", err)
+		return false, errors.GetErrorMessage(ctx, &errors.DatabaseError{errors.DatabaseGenericError, err.Error()})
+	}
 	if dbAwsAccount.UserID == user.Id {
 		return true, nil
 	}
@@ -129,6 +133,10 @@ func safetyCheckByShareIdAndPermissionLevel(ctx context.Context, tx *sql.Tx, sha
 		return false, errors.GetErrorMessage(ctx, &errors.DatabaseError{errors.DatabaseGenericError, err.Error()})
 	}
 	dbAwsAccount, err := models.AwsAccountByID(tx, dbShareAccount.AccountID)
+	if err != nil {
+		logger.Error("Error while retrieving AWS account", err)
+		return false, errors.GetErrorMessage(ctx, &errors.DatabaseError{errors.DatabaseGenericError, err.Error()})
+	}
 	if dbAwsAccount.UserID == user.Id {
 		return true, nil
 	}

--- a/util/req/reqValidator.go
+++ b/util/req/reqValidator.go
@@ -122,7 +122,7 @@ func createValidatorForField(typ reflect.Type, fld reflect.StructField) (interna
 // validators. When called it will allways run all child validators, returning
 // all errors.
 func aggregateValidators(fvs []internalValidator) internalValidator {
-	if fvs == nil || len(fvs) == 0 {
+	if len(fvs) == 0 {
 		return nil
 	} else {
 		return func(v reflect.Value) error {


### PR DESCRIPTION
Numerous issues are fixed:
- Unmerged adjacent declarations and assignments (`anomaliesDetection`, `aws`)
- Unused values of certain variables (`costs`, `s3`, `users`)
- Redundant returns (`reports`)
- Bad usage of loops instead of just doing `append(a, b...)` (much simpler and very likely faster) (`cache`, `reports`, `routes`)
- Using `errors.New(fmt.Sprintf` instead of just `fmt.Errorf` (`aws`, `reports`, `users`)
- Using `fmt.Sprintf` when unnecessary (`aws`, `tagging`, `users`)
- Mispelled or missing type or func names in comments (`aws`, `costs`, `db`, `es`, `onDemandToRI`, `routes`, `tagging`, `usageReports`, `users`)
- Code that was way too verbose (`tagging.checkUserTagbotFreeTrial`)
- Using `time.Now().Sub` instead of `time.Since` (`routes`, `tagging`, `unusedAccounts`, `users`)
- Using `t.Add(time.Now())` instead of `time.Until(t)` (`unusedAccounts`)
- Unnecessary checks for `nil`, primarily w.r.t. guarding uses of `len` (`usageReports`, `users`, `util`)
- Useless use of `make(map[T]T, 0)` (often corrected to a more accurate size) (`aws`, `models`, `usageReports`)
- Unnecessary usage of `_` where no identifier is needed (`aws`, `costs`, `plugins`, `users`, `routes`)
- Useless usage of `break` (`errors`)
- Bad usage of type assertions that could be optimized (`errors`)
- Useless code that uses up time with no used results (`aws`)
- Fix some empty branches (`anomaliesDetection`, `server`)
- Usage of `+= 1` instead of `++` (`aws`, `costs`, `onDemandToRI`, `plugins`)
- Uncommented usage of blank imports that should probably be at least documented a bit (`db`, `plugins`)