### PR TITLE
Fixed Route53 throttling

### DIFF
--- a/aws/usageReports/route53/dailyReport.go
+++ b/aws/usageReports/route53/dailyReport.go
@@ -34,11 +34,16 @@ import (
 func fetchDailyRoute53List(ctx context.Context, creds *credentials.Credentials, region string, hostedZoneChan chan HostedZone) error {
 	defer close(hostedZoneChan)
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
+
+	// Make it so that the AWS session will automatically retry our requests if we get throttled. Especially important for Route53 since we'll get throttled if we do more than 5 requests per second
+	maxRetries := 20
 	sess := session.Must(session.NewSession(&aws.Config{
 		Credentials: creds,
 		Region:      aws.String(region),
+		MaxRetries:  &maxRetries,
 	}))
 	svc := route53.New(sess)
+
 	hostedZones, err := svc.ListHostedZones(nil)
 	if err != nil {
 		logger.Error("Error when describing Route53 HostedZones", err.Error())


### PR DESCRIPTION
When a lot of Route53 requests were done, it would result in getting a lot of throttling from AWS. There's a long story behind finally figuring this existed, including ~100 lines of discarded code, but finally a much simpler solution was found in the depths of the AWS Go SDK, which includes an automatic retryer which essentially just solves this problem