### PR TITLE
Make db/schema.sql and db/migrations completely consistent

### DIFF
--- a/db/migration/0006_add_aws_account_update_job.sql
+++ b/db/migration/0006_add_aws_account_update_job.sql
@@ -15,7 +15,7 @@
 CREATE TABLE aws_account_update_job (
 	id                     INTEGER      NOT NULL AUTO_INCREMENT,
 	created                TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	aws_account_id 				 INTEGER      NOT NULL,
+	aws_account_id         INTEGER      NOT NULL,
 	completed              TIMESTAMP    NOT NULL DEFAULT 0,
 	worker_id              VARCHAR(255) NOT NULL,
 	jobError               VARCHAR(255) NOT NULL DEFAULT "",

--- a/db/migration/0009_add_aws_customer_identifier.sql
+++ b/db/migration/0009_add_aws_customer_identifier.sql
@@ -1,4 +1,4 @@
---   Copyright 2017 MSolution.IO
+--   Copyright 2018 MSolution.IO
 --
 --   Licensed under the Apache License, Version 2.0 (the "License");
 --   you may not use this file except in compliance with the License.

--- a/db/migration/0012_shared_account.sql
+++ b/db/migration/0012_shared_account.sql
@@ -13,12 +13,12 @@
 --   limitations under the License.
 
 CREATE TABLE shared_account (
-  id                     INTEGER      NOT NULL AUTO_INCREMENT,
-  account_id             INTEGER      NOT NULL,
-  user_id                INTEGER      NOT NULL,
-  user_permission        INTEGER      NOT NULL DEFAULT 0,
-  sharing_accepted       BOOL         NOT NULL DEFAULT 0,
-  CONSTRAINT PRIMARY KEY (id),
-  CONSTRAINT foreign_aws_account FOREIGN KEY (account_id) REFERENCES aws_account(id) ON DELETE CASCADE,
-  CONSTRAINT foreign_user_id FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+       id                     INTEGER   NOT NULL AUTO_INCREMENT,
+       account_id             INTEGER   NOT NULL,
+       user_id                INTEGER   NOT NULL,
+       user_permission        INTEGER   NOT NULL DEFAULT 0,
+       sharing_accepted       BOOL      NOT NULL DEFAULT 0,
+       CONSTRAINT PRIMARY KEY (id),
+       CONSTRAINT foreign_aws_account FOREIGN KEY (account_id) REFERENCES aws_account(id) ON DELETE CASCADE,
+       CONSTRAINT foreign_user_id FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
 );

--- a/db/migration/0034_add_elasticache_and_elasticsearch_to_spreadsheet_reports.sql
+++ b/db/migration/0034_add_elasticache_and_elasticsearch_to_spreadsheet_reports.sql
@@ -13,7 +13,7 @@
 --   limitations under the License.
 
 ALTER TABLE aws_account_reports_job ADD (
-  esUsageReportError VARCHAR(255) NOT NULL DEFAULT "",
-  elasticacheUsageReportError VARCHAR(255) NOT NULL DEFAULT "",
-  lambdaUsageReportError VARCHAR(255) NOT NULL DEFAULT ""
+      esUsageReportError VARCHAR(255) NOT NULL DEFAULT "",
+      elasticacheUsageReportError VARCHAR(255) NOT NULL DEFAULT "",
+      lambdaUsageReportError VARCHAR(255) NOT NULL DEFAULT ""
 );

--- a/db/migration/0035_master_account_spreadsheet_reports.sql
+++ b/db/migration/0035_master_account_spreadsheet_reports.sql
@@ -13,21 +13,21 @@
 --   limitations under the License.
 
 CREATE TABLE aws_account_master_reports_job (
-	id                          INTEGER      NOT NULL AUTO_INCREMENT,
-	created                     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	aws_account_id              INTEGER      NOT NULL,
-	completed                   TIMESTAMP    NOT NULL DEFAULT 0,
-	worker_id                   VARCHAR(255) NOT NULL,
-	jobError                    VARCHAR(255) NOT NULL DEFAULT "",
-	spreadsheetError            VARCHAR(255) NOT NULL DEFAULT "",
-	costDiffError               VARCHAR(255) NOT NULL DEFAULT "",
-	ec2UsageReportError         VARCHAR(255) NOT NULL DEFAULT "",
-	rdsUsageReportError         VARCHAR(255) NOT NULL DEFAULT "",
-	esUsageReportError          VARCHAR(255) NOT NULL DEFAULT "",
-	elasticacheUsageReportError VARCHAR(255) NOT NULL DEFAULT "",
-	lambdaUsageReportError      VARCHAR(255) NOT NULL DEFAULT "",
-	CONSTRAINT PRIMARY KEY (id),
-	CONSTRAINT foreign_aws_account FOREIGN KEY (aws_account_id) REFERENCES aws_account(id) ON DELETE CASCADE
+       id                          INTEGER      NOT NULL AUTO_INCREMENT,
+       created                     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+       aws_account_id              INTEGER      NOT NULL,
+       completed                   TIMESTAMP    NOT NULL DEFAULT 0,
+       worker_id                   VARCHAR(255) NOT NULL,
+       jobError                    VARCHAR(255) NOT NULL DEFAULT "",
+       spreadsheetError            VARCHAR(255) NOT NULL DEFAULT "",
+       costDiffError               VARCHAR(255) NOT NULL DEFAULT "",
+       ec2UsageReportError         VARCHAR(255) NOT NULL DEFAULT "",
+       rdsUsageReportError         VARCHAR(255) NOT NULL DEFAULT "",
+       esUsageReportError          VARCHAR(255) NOT NULL DEFAULT "",
+       elasticacheUsageReportError VARCHAR(255) NOT NULL DEFAULT "",
+       lambdaUsageReportError      VARCHAR(255) NOT NULL DEFAULT "",
+       CONSTRAINT PRIMARY KEY (id),
+       CONSTRAINT foreign_aws_account FOREIGN KEY (aws_account_id) REFERENCES aws_account(id) ON DELETE CASCADE
 );
 
 ALTER TABLE aws_account ADD last_master_spreadsheet_report_generation DATETIME NOT NULL DEFAULT "1970-01-01 00:00:00";

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -242,7 +242,7 @@ ALTER TABLE aws_account_update_job ADD ec2Error VARCHAR(255) NOT NULL DEFAULT ""
 
 ALTER TABLE aws_bill_repository ADD grace_update DATETIME NOT NULL DEFAULT "1970-01-01 00:00:00";
 
---   Copyright 2017 MSolution.IO
+--   Copyright 2018 MSolution.IO
 --
 --   Licensed under the Apache License, Version 2.0 (the "License");
 --   you may not use this file except in compliance with the License.

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -76,6 +76,7 @@ CREATE TABLE aws_product_pricing_ec2 (
 	ecu VARCHAR(255) NOT NULL,
 	CONSTRAINT PRIMARY KEY (etag, sku)
 );
+
 --   Copyright 2017 MSolution.IO
 --
 --   Licensed under the Apache License, Version 2.0 (the "License");
@@ -102,6 +103,7 @@ CREATE TABLE aws_bill_update_job (
 	CONSTRAINT PRIMARY KEY (id),
 	CONSTRAINT foreign_bill_repository FOREIGN KEY (aws_bill_repository_id) REFERENCES aws_bill_repository(id) ON DELETE CASCADE
 );
+
 --   Copyright 2017 MSolution.IO
 --
 --   Licensed under the Apache License, Version 2.0 (the "License");
@@ -118,6 +120,7 @@ CREATE TABLE aws_bill_update_job (
 
 ALTER TABLE user ADD parent_user_id INTEGER NULL;
 ALTER TABLE user ADD CONSTRAINT parent_user FOREIGN KEY (parent_user_id) REFERENCES user(id) ON DELETE CASCADE;
+
 --   Copyright 2018 MSolution.IO
 --
 --   Licensed under the Apache License, Version 2.0 (the "License");
@@ -133,6 +136,7 @@ ALTER TABLE user ADD CONSTRAINT parent_user FOREIGN KEY (parent_user_id) REFEREN
 --   limitations under the License.
 
 ALTER TABLE aws_bill_repository ADD status VARCHAR(255) NULL;
+
 --   Copyright 2018 MSolution.IO
 --
 --   Licensed under the Apache License, Version 2.0 (the "License");
@@ -238,7 +242,7 @@ ALTER TABLE aws_account_update_job ADD ec2Error VARCHAR(255) NOT NULL DEFAULT ""
 
 ALTER TABLE aws_bill_repository ADD grace_update DATETIME NOT NULL DEFAULT "1970-01-01 00:00:00";
 
---   Copyright 2018 MSolution.IO
+--   Copyright 2017 MSolution.IO
 --
 --   Licensed under the Apache License, Version 2.0 (the "License");
 --   you may not use this file except in compliance with the License.
@@ -309,14 +313,14 @@ ALTER TABLE aws_account ADD payer BOOL NOT NULL DEFAULT "1";
 --   limitations under the License.
 
 CREATE TABLE shared_account (
-  id                     INTEGER   NOT NULL AUTO_INCREMENT,
-  account_id             INTEGER   NOT NULL,
-  user_id                INTEGER   NOT NULL,
-  user_permission        INTEGER   NOT NULL DEFAULT 0,
-  sharing_accepted       BOOL      NOT NULL DEFAULT 0,
-  CONSTRAINT PRIMARY KEY (id),
-  CONSTRAINT foreign_aws_account FOREIGN KEY (account_id) REFERENCES aws_account(id) ON DELETE CASCADE,
-  CONSTRAINT foreign_user_id FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+       id                     INTEGER   NOT NULL AUTO_INCREMENT,
+       account_id             INTEGER   NOT NULL,
+       user_id                INTEGER   NOT NULL,
+       user_permission        INTEGER   NOT NULL DEFAULT 0,
+       sharing_accepted       BOOL      NOT NULL DEFAULT 0,
+       CONSTRAINT PRIMARY KEY (id),
+       CONSTRAINT foreign_aws_account FOREIGN KEY (account_id) REFERENCES aws_account(id) ON DELETE CASCADE,
+       CONSTRAINT foreign_user_id FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
 );
 
 --   Copyright 2018 MSolution.IO
@@ -333,7 +337,7 @@ CREATE TABLE shared_account (
 --   See the License for the specific language governing permissions and
 --   limitations under the License.
 
-ALTER TABLE user ADD aws_customer_entitlement bool NOT NULL DEFAULT 1;
+ALTER TABLE user ADD aws_customer_entitlement BOOL NOT NULL DEFAULT 1;
 
 --   Copyright 2018 MSolution.IO
 --
@@ -751,9 +755,9 @@ ALTER TABLE aws_account_update_job ADD riError VARCHAR(255) NOT NULL DEFAULT "";
 --   limitations under the License.
 
 ALTER TABLE aws_account_reports_job ADD (
-	esUsageReportError VARCHAR(255) NOT NULL DEFAULT "",
-	elasticacheUsageReportError VARCHAR(255) NOT NULL DEFAULT "",
-	lambdaUsageReportError VARCHAR(255) NOT NULL DEFAULT ""
+      esUsageReportError VARCHAR(255) NOT NULL DEFAULT "",
+      elasticacheUsageReportError VARCHAR(255) NOT NULL DEFAULT "",
+      lambdaUsageReportError VARCHAR(255) NOT NULL DEFAULT ""
 );
 
 --   Copyright 2018 MSolution.IO
@@ -771,21 +775,21 @@ ALTER TABLE aws_account_reports_job ADD (
 --   limitations under the License.
 
 CREATE TABLE aws_account_master_reports_job (
-  id                          INTEGER      NOT NULL AUTO_INCREMENT,
-  created                     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  aws_account_id              INTEGER      NOT NULL,
-  completed                   TIMESTAMP    NOT NULL DEFAULT 0,
-  worker_id                   VARCHAR(255) NOT NULL,
-  jobError                    VARCHAR(255) NOT NULL DEFAULT "",
-  spreadsheetError            VARCHAR(255) NOT NULL DEFAULT "",
-  costDiffError               VARCHAR(255) NOT NULL DEFAULT "",
-  ec2UsageReportError         VARCHAR(255) NOT NULL DEFAULT "",
-  rdsUsageReportError         VARCHAR(255) NOT NULL DEFAULT "",
-  esUsageReportError          VARCHAR(255) NOT NULL DEFAULT "",
-  elasticacheUsageReportError VARCHAR(255) NOT NULL DEFAULT "",
-  lambdaUsageReportError      VARCHAR(255) NOT NULL DEFAULT "",
-  CONSTRAINT PRIMARY KEY (id),
-  CONSTRAINT foreign_aws_account FOREIGN KEY (aws_account_id) REFERENCES aws_account(id) ON DELETE CASCADE
+       id                          INTEGER      NOT NULL AUTO_INCREMENT,
+       created                     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+       aws_account_id              INTEGER      NOT NULL,
+       completed                   TIMESTAMP    NOT NULL DEFAULT 0,
+       worker_id                   VARCHAR(255) NOT NULL,
+       jobError                    VARCHAR(255) NOT NULL DEFAULT "",
+       spreadsheetError            VARCHAR(255) NOT NULL DEFAULT "",
+       costDiffError               VARCHAR(255) NOT NULL DEFAULT "",
+       ec2UsageReportError         VARCHAR(255) NOT NULL DEFAULT "",
+       rdsUsageReportError         VARCHAR(255) NOT NULL DEFAULT "",
+       esUsageReportError          VARCHAR(255) NOT NULL DEFAULT "",
+       elasticacheUsageReportError VARCHAR(255) NOT NULL DEFAULT "",
+       lambdaUsageReportError      VARCHAR(255) NOT NULL DEFAULT "",
+       CONSTRAINT PRIMARY KEY (id),
+       CONSTRAINT foreign_aws_account FOREIGN KEY (aws_account_id) REFERENCES aws_account(id) ON DELETE CASCADE
 );
 
 ALTER TABLE aws_account ADD last_master_spreadsheet_report_generation DATETIME NOT NULL DEFAULT "1970-01-01 00:00:00";
@@ -966,8 +970,8 @@ CREATE TABLE aws_account_tags_reports_job (
 	CONSTRAINT foreign_aws_account FOREIGN KEY (aws_account_id) REFERENCES aws_account(id) ON DELETE CASCADE
 );
 
-ALTER TABLE aws_account ADD last_tags_spreadsheet_report_generation DATETIME NOT NULL DEFAULT "1970-01-01 00:00:00";
-ALTER TABLE aws_account ADD next_tags_spreadsheet_report_generation DATETIME NOT NULL DEFAULT "1970-01-01 00:00:00";
+ALTER TABLE aws_account ADD last_tags_spreadsheet_report_generation DATETIME NOT NULL DEFAULT '1970-01-01 00:00:00';
+ALTER TABLE aws_account ADD next_tags_spreadsheet_report_generation DATETIME NOT NULL DEFAULT '1970-01-01 00:00:00';
 
 CREATE OR REPLACE VIEW aws_account_tags_spreadsheets_reports_due_update AS
 SELECT * FROM aws_account WHERE next_tags_spreadsheet_report_generation <= NOW()
@@ -1121,7 +1125,7 @@ CREATE TABLE user_onboard_tagbot_job (
 	CONSTRAINT foreign_user FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
 );
 
---   Copyright 2020 MSolution.IO
+--   Copyright 2019 MSolution.IO
 --
 --   Licensed under the Apache License, Version 2.0 (the "License");
 --   you may not use this file except in compliance with the License.

--- a/documentation/models.md
+++ b/documentation/models.md
@@ -2,7 +2,11 @@
 
 The `xo` command-line tool can be useful in order to create code to interact with the SQL database. It generates Go code based on a database schema.
 
-In order to modify the database architecture, you must add a migration file in the `db/migration` folder. Your migration should be added at the end of the 'db/schema.sql' file. In a development environment, you have to manually apply the migration before you can continue.
+In order to modify the database architecture, you must add a migration file in the `db/migration` folder. Your migration should be added at the end of the `db/schema.sql` file. In a development environment, you have to manually apply the migration before you can continue.
+
+A command such as this should be used to check that `db/schema.sql` corresponds to the files contained in `db/migration` (it prints the difference, i.e. outputs nothing if `db/schema.sql` is correct):
+
+`diff -u db/schema.sql <(awk 'FNR==1{print ""}1' db/migration/*.sql | tail -n+2)`
 
 Once the database is modified, you can use the `xo` tool to generate go models:
 


### PR DESCRIPTION
Before this, it seems like they were fully functionally equivalent, but making it so in a way that can be checked in a single command is a lot more useful and makes checking/testing for equivalence a lot easier.