### PR TITLE
Fix HTTP status enums being used inconsistently

### DIFF
--- a/aws/external.go
+++ b/aws/external.go
@@ -55,10 +55,10 @@ func NextExternal(r *http.Request, a routes.Arguments) (int, interface{}) {
 		err := user.UpdateNextExternal(ctx, tx)
 		if err != nil {
 			logger.Error("Failed to update external ID.", err.Error())
-			return 500, "Failed get external ID."
+			return http.StatusInternalServerError, "Failed get external ID."
 		}
 	}
-	return 200, nextExternalResponseBody{
+	return http.StatusOK, nextExternalResponseBody{
 		External:  user.NextExternal,
 		AccountId: AccountId(),
 	}

--- a/aws/routes/routeAwsGet.go
+++ b/aws/routes/routeAwsGet.go
@@ -222,9 +222,9 @@ func getAwsAccount(r *http.Request, a routes.Arguments) (int, interface{}) {
 		awsAccounts, awsErr = aws.GetAwsAccountsFromUser(u, tx)
 	}
 	if awsErr == nil {
-		return 200, awsAccounts
+		return http.StatusOK, awsAccounts
 	} else {
 		l.Error("failed to get user's AWS accounts", awsErr.Error())
-		return 500, errors.New("failed to retrieve AWS accounts")
+		return http.StatusInternalServerError, errors.New("failed to retrieve AWS accounts")
 	}
 }

--- a/aws/routes/routeAwsPost.go
+++ b/aws/routes/routeAwsPost.go
@@ -71,7 +71,7 @@ func postAwsAccountWithValidBody(r *http.Request, tx *sql.Tx, user users.User, b
 	}
 	if account.External != user.NextExternal {
 		logger.Warning("tried to add AWS account with bad external", account)
-		return 400, errors.New("incorrect external. Use /aws/next to get expected external")
+		return http.StatusBadRequest, errors.New("incorrect external. Use /aws/next to get expected external")
 	} else if err := testAndCreateAwsAccount(ctx, tx, &account, &user); err == nil {
 		err = setNeedsTagbotOnboarding(tx, body, account)
 		if err != nil {
@@ -80,13 +80,13 @@ func postAwsAccountWithValidBody(r *http.Request, tx *sql.Tx, user users.User, b
 				"err":     err.Error(),
 			})
 		}
-		return 200, account
+		return http.StatusOK, account
 	} else {
 		switch err {
 		case errInvalidAccount:
-			return 400, err
+			return http.StatusBadRequest, err
 		default:
-			return 500, err
+			return http.StatusInternalServerError, err
 		}
 	}
 }

--- a/aws/routes/routeAwsStatus.go
+++ b/aws/routes/routeAwsStatus.go
@@ -23,12 +23,12 @@ func getAwsAccountsStatus(r *http.Request, a routes.Arguments) (int, interface{}
 	awsAccounts, err := aws.GetAwsAccountsFromUser(u, tx)
 	if err != nil {
 		l.Error("failed to get user's AWS accounts", err.Error())
-		return 500, errors.New("failed to retrieve AWS accounts")
+		return http.StatusInternalServerError, errors.New("failed to retrieve AWS accounts")
 	}
 	awsAccountsWithBillRepositories, err = s3.WrapAwsAccountsWithBillRepositories(awsAccounts, tx)
 	if err != nil {
 		l.Error("failed to get AWS accounts' bill repositories", err.Error())
-		return 500, errors.New("failed to retrieve bill repositories")
+		return http.StatusInternalServerError, errors.New("failed to retrieve bill repositories")
 	}
 	billRepositoriesIds := make([]int, 0)
 	for _, awsAccount := range awsAccountsWithBillRepositories {
@@ -37,5 +37,5 @@ func getAwsAccountsStatus(r *http.Request, a routes.Arguments) (int, interface{}
 		}
 	}
 	result := s3.WrapAwsAccountsWithBillRepositoriesWithPendingWithStatus(awsAccountsWithBillRepositories, tx)
-	return 200, result
+	return http.StatusOK, result
 }

--- a/aws/usageReports/history/history.go
+++ b/aws/usageReports/history/history.go
@@ -74,7 +74,7 @@ func GetHistoryDate() (time.Time, time.Time) {
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequestForCost(ctx context.Context, client *elastic.Client, aa aws.AwsAccount,
 	startDate, endDate time.Time, product string, partition int) (*elastic.SearchResult, int, error) {

--- a/costs/anomalies/anomalies_route.go
+++ b/costs/anomalies/anomalies_route.go
@@ -82,7 +82,7 @@ func init() {
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, parsedParams anomalyType.AnomalyEsQueryParams) (*elastic.SearchResult, int, error) {
 	l := jsonlog.LoggerFromContextOrDefault(ctx)

--- a/costs/anomalies/filters_route.go
+++ b/costs/anomalies/filters_route.go
@@ -152,7 +152,7 @@ func postAnomaliesFiltersWithValidFilters(r *http.Request, tx *sql.Tx, dbUser *m
 						"error":  err.Error(),
 					})
 				} else {
-					return 200, filters
+					return http.StatusOK, filters
 				}
 			}
 		}

--- a/costs/costs_route.go
+++ b/costs/costs_route.go
@@ -107,7 +107,7 @@ func validateCriteriaParam(parsedParams EsQueryParams) error {
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func MakeElasticSearchRequestAndParseIt(ctx context.Context, parsedParams EsQueryParams) (es.SimplifiedCostsDocument, int, error) {
 	l := jsonlog.LoggerFromContextOrDefault(ctx)

--- a/costs/diff/diff_route.go
+++ b/costs/diff/diff_route.go
@@ -90,7 +90,7 @@ func init() {
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empy data
 func makeElasticSearchRequest(ctx context.Context, parsedParams esQueryParams) (*elastic.SearchResult, int, error) {
 	l := jsonlog.LoggerFromContextOrDefault(ctx)

--- a/costs/tags/tags_keys.go
+++ b/costs/tags/tags_keys.go
@@ -71,7 +71,7 @@ func GetTagsKeysWithParsedParams(ctx context.Context, params TagsKeysQueryParams
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequestForTagsKeys(ctx context.Context, params TagsKeysQueryParams,
 	client *elastic.Client) (*elastic.SearchResult, int, error) {

--- a/costs/tags/tags_values.go
+++ b/costs/tags/tags_values.go
@@ -209,7 +209,7 @@ func getAggregationForTagsValues(params TagsValuesQueryParams, filter FilterType
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequestForTagsValues(ctx context.Context, params TagsValuesQueryParams, client *elastic.Client) (*elastic.SearchResult, int, error) {
 	l := jsonlog.LoggerFromContextOrDefault(ctx)

--- a/onDemandToRI/ec2/es_request_constructor.go
+++ b/onDemandToRI/ec2/es_request_constructor.go
@@ -61,7 +61,7 @@ type (
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, parsedParams RiEc2QueryParams,
 	esSearchParams func(RiEc2QueryParams, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {

--- a/plugins/account/core/route.go
+++ b/plugins/account/core/route.go
@@ -62,7 +62,7 @@ func init() {
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empy data
 func makeElasticSearchPluginsRequest(ctx context.Context, parsedParams pluginsQueryParams) (*elastic.SearchResult, int, error) {
 	l := jsonlog.LoggerFromContextOrDefault(ctx)

--- a/routes/decoratorQueryArgs.go
+++ b/routes/decoratorQueryArgs.go
@@ -208,7 +208,7 @@ func parseArg(arg QueryArg, r *http.Request, a Arguments) (int, error) {
 }
 
 // Decorate is the function called to apply the decorators to an endpoint. It returns
-// a function. This function produces a 400 error code with a json error message or
+// a function. This function produces a 400 Bad Request error code with a json error message or
 // calls the next IntermediateHandler.
 // The goal of this function is to get the URL parameters to store them in
 // the Arguments.

--- a/routes/decoratorQueryArgs_test.go
+++ b/routes/decoratorQueryArgs_test.go
@@ -35,7 +35,7 @@ var (
 )
 
 func argHandler(r *http.Request, a Arguments) (int, interface{}) {
-	return 200, a
+	return http.StatusOK, a
 }
 
 func intSliceIsEqual(first, second []int) bool {
@@ -134,8 +134,8 @@ func TestOverflowIntArg(t *testing.T) {
 	request := httptest.NewRequest("GET", "/test?testInt="+overflowInt64Str, nil)
 	response := httptest.NewRecorder()
 	status, body := h.Func(response, request, Arguments{})
-	if status != 400 {
-		t.Errorf("Expected 400. Got %d (%s)", status, body)
+	if status != http.StatusBadRequest {
+		t.Errorf("Expected http.StatusBadRequest (400). Got %d (%s)", status, body)
 	}
 	if err, ok := body.(error); !ok {
 		t.Errorf("Expected error.")
@@ -151,8 +151,8 @@ func TestRightUintArg(t *testing.T) {
 	request := httptest.NewRequest("GET", "/test?testUint=84", nil)
 	response := httptest.NewRecorder()
 	status, body := h.Func(response, request, Arguments{})
-	if status != 200 {
-		t.Errorf("Expected 200. Got %d (%s)", status, body)
+	if status != http.StatusOK {
+		t.Errorf("Expected http.StatusOK (200). Got %d (%s)", status, body)
 	} else if args, ok := body.(Arguments); !ok {
 		t.Errorf("Expected type Arguments.")
 	} else if testUint, ok := args[QueryArgTestUint]; !ok {
@@ -169,8 +169,8 @@ func TestOptionalStringArg(t *testing.T) {
 	request := httptest.NewRequest("GET", "/test?testString=Hi!", nil)
 	response := httptest.NewRecorder()
 	status, body := h.Func(response, request, Arguments{})
-	if status != 200 {
-		t.Errorf("Expected 200. Got %d (%s)", status, body)
+	if status != http.StatusOK {
+		t.Errorf("Expected http.StatusOK (200). Got %d (%s)", status, body)
 	} else if args, ok := body.(Arguments); !ok {
 		t.Errorf("Expected type Arguments.")
 	} else if testString, ok := args[QueryArgTestOptionalString]; !ok {
@@ -182,8 +182,8 @@ func TestOptionalStringArg(t *testing.T) {
 	request = httptest.NewRequest("GET", "/test", nil)
 	response = httptest.NewRecorder()
 	status, body = h.Func(response, request, Arguments{})
-	if status != 200 {
-		t.Errorf("Expected 200. Got %d (%s)", status, body)
+	if status != http.StatusOK {
+		t.Errorf("Expected http.StatusOK (200). Got %d (%s)", status, body)
 	} else if args, ok := body.(Arguments); !ok {
 		t.Errorf("Expected type Arguments.")
 	} else if _, ok := args[QueryArgTestOptionalString]; ok {
@@ -200,8 +200,8 @@ func TestNegativeUintArg(t *testing.T) {
 	request := httptest.NewRequest("GET", "/test?testUint=-21", nil)
 	response := httptest.NewRecorder()
 	status, body := h.Func(response, request, Arguments{})
-	if status != 400 {
-		t.Errorf("Expected 400. Got %d (%s)", status, body)
+	if status != http.StatusBadRequest {
+		t.Errorf("Expected http.StatusBadRequest (400). Got %d (%s)", status, body)
 	}
 	if err, ok := body.(error); !ok {
 		t.Errorf("Expected error.")
@@ -237,8 +237,8 @@ func TestMultipleArg(t *testing.T) {
 	request := httptest.NewRequest("GET", "/test?"+strings.Join(paramsURL, "&"), nil)
 	response := httptest.NewRecorder()
 	status, body := h.Func(response, request, Arguments{})
-	if status != 200 {
-		t.Errorf("Expected 200. Got %d (%v)", status, body)
+	if status != http.StatusOK {
+		t.Errorf("Expected http.StatusOK (200). Got %d (%v)", status, body)
 	} else if args, ok := body.(Arguments); !ok {
 		t.Errorf("Expected type Arguments.")
 	} else {

--- a/routes/routes_test.go
+++ b/routes/routes_test.go
@@ -84,7 +84,7 @@ const testRegistrationPattern = "/foo"
 
 func TestRegistration(t *testing.T) {
 	var handlerRun bool
-	f := func(_ *http.Request, _ Arguments) (int, interface{}) { handlerRun = true; return 200, nil }
+	f := func(_ *http.Request, _ Arguments) (int, interface{}) { handlerRun = true; return http.StatusOK, nil }
 	h := H(f)
 	h.Register(testRegistrationPattern)
 	if l := len(RegisteredHandlers); l != 1 {

--- a/s3/costs/s3_costs_route.go
+++ b/s3/costs/s3_costs_route.go
@@ -91,7 +91,7 @@ func init() {
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empy data
 func makeElasticSearchRequest(ctx context.Context, parsedParams S3QueryParams,
 	queryDataType string) (*elastic.SearchResult, int, error) {

--- a/tagging/routes/routeGetResources.go
+++ b/tagging/routes/routeGetResources.go
@@ -77,7 +77,7 @@ func GetResources(ctx context.Context, params ResourcesRequestBody, user users.U
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, params ResourcesRequestBody, user users.User,
 	esSearchParams func(ResourcesRequestBody, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {

--- a/usageReports/ebs/get_ebs_data.go
+++ b/usageReports/ebs/get_ebs_data.go
@@ -36,7 +36,7 @@ import (
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, parsedParams EbsQueryParams,
 	esSearchParams func(EbsQueryParams, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {

--- a/usageReports/ec2/get_ec2_data.go
+++ b/usageReports/ec2/get_ec2_data.go
@@ -36,7 +36,7 @@ import (
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, parsedParams Ec2QueryParams,
 	esSearchParams func(Ec2QueryParams, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {

--- a/usageReports/ec2Coverage/get_ec2_coverage_data.go
+++ b/usageReports/ec2Coverage/get_ec2_coverage_data.go
@@ -36,7 +36,7 @@ import (
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, parsedParams Ec2CoverageQueryParams) (*elastic.SearchResult, int, error) {
 	l := jsonlog.LoggerFromContextOrDefault(ctx)

--- a/usageReports/elasticache/get_elasticache_data.go
+++ b/usageReports/elasticache/get_elasticache_data.go
@@ -36,7 +36,7 @@ import (
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, parsedParams ElastiCacheQueryParams,
 	esSearchParams func(ElastiCacheQueryParams, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {

--- a/usageReports/es/get_es_data.go
+++ b/usageReports/es/get_es_data.go
@@ -36,7 +36,7 @@ import (
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, parsedParams EsQueryParams,
 	esSearchParams func(EsQueryParams, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {

--- a/usageReports/instanceCount/get_instanceCount_data.go
+++ b/usageReports/instanceCount/get_instanceCount_data.go
@@ -36,7 +36,7 @@ import (
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, parsedParams InstanceCountQueryParams,
 	esSearchParams func(InstanceCountQueryParams, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {

--- a/usageReports/lambda/get_lambda_data.go
+++ b/usageReports/lambda/get_lambda_data.go
@@ -36,7 +36,7 @@ import (
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, parsedParams LambdaQueryParams,
 	esSearchParams func(LambdaQueryParams, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {

--- a/usageReports/rds/get_rds_data.go
+++ b/usageReports/rds/get_rds_data.go
@@ -36,7 +36,7 @@ import (
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, parsedParams RdsQueryParams,
 	esSearchParams func(RdsQueryParams, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {

--- a/usageReports/riEc2/get_ec2_data.go
+++ b/usageReports/riEc2/get_ec2_data.go
@@ -36,7 +36,7 @@ import (
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, parsedParams ReservedInstancesQueryParams,
 	esSearchParams func(ReservedInstancesQueryParams, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {

--- a/usageReports/riRds/get_rds_data.go
+++ b/usageReports/riRds/get_rds_data.go
@@ -36,7 +36,7 @@ import (
 // It will return the data, an http status code (as int) and an error.
 // Because an error can be generated, but is not critical and is not needed to be known by
 // the user (e.g if the index does not exists because it was not yet indexed ) the error will
-// be returned, but instead of having a 500 status code, it will return the provided status code
+// be returned, but instead of having a 500 Internal Server Error status code, it will return the provided status code
 // with empty data
 func makeElasticSearchRequest(ctx context.Context, parsedParams ReservedInstancesQueryParams,
 	esSearchParams func(ReservedInstancesQueryParams, *elastic.Client, string) *elastic.SearchService) (*elastic.SearchResult, int, error) {

--- a/users/create.go
+++ b/users/create.go
@@ -151,7 +151,7 @@ func createUser(request *http.Request, a routes.Arguments) (int, interface{}) {
 		var err error
 		result, err = checkAwsTokenLegitimacy(ctx, body.AwsToken)
 		if err != nil {
-			return 409, errors.New("Fail to check the AWS token")
+			return http.StatusConflict, errors.New("Fail to check the AWS token")
 		}
 		awsCustomer := result.CustomerIdentifier
 		awsCustomerConvert = *awsCustomer
@@ -161,11 +161,11 @@ func createUser(request *http.Request, a routes.Arguments) (int, interface{}) {
 	} else if body.Origin == "trackit" {
 		code, resp = createUserWithValidBody(request, body, tx, awsCustomerConvert)
 	} else {
-		return 400, errors.New("Can't create a user with " + body.Origin + " as AccountType. Unknown Origin.")
+		return http.StatusBadRequest, errors.New("Can't create a user with " + body.Origin + " as AccountType. Unknown Origin.")
 	}
 	// Add the default role to the new account. No error is returned in case of failure
 	// The billing repository is not processed instantly
-	if code == 200 && config.DefaultRole != "" && config.DefaultRoleName != "" &&
+	if code == http.StatusOK && config.DefaultRole != "" && config.DefaultRoleName != "" &&
 		config.DefaultRoleExternal != "" && config.DefaultRoleBucket != "" {
 		addDefaultRole(request, resp.(User), tx)
 	}
@@ -185,14 +185,14 @@ func createUserWithValidBody(request *http.Request, body createUserRequestBody, 
 				"err":     err.Error(),
 			})
 		}
-		return 200, user
+		return http.StatusOK, user
 	} else {
 		logger.Error(err.Error(), nil)
 		errSplit := strings.Split(err.Error(), ":")
 		if len(errSplit) >= 1 && errSplit[0] == "Error 1062" {
-			return 409, errors.New("Account already exists.")
+			return http.StatusConflict, errors.New("Account already exists.")
 		} else {
-			return 500, errors.New("Failed to create user.")
+			return http.StatusInternalServerError, errors.New("Failed to create user.")
 		}
 	}
 }
@@ -204,7 +204,7 @@ func createTagbotUserWithValidBody(request *http.Request, body createUserRequest
 	if err == nil {
 		logger.Info("User created.", user)
 		if err := CreateTagbotUser(ctx, tx, user.Id, customerIdentifier); err != nil {
-			return 500, errors.New("Failed to create user.")
+			return http.StatusInternalServerError, errors.New("Failed to create user.")
 		}
 		if err := entitlement.CheckUserEntitlements(request.Context(), tx, user.Id); err != nil {
 			logger.Error("Could not check new user's entitlements", map[string]interface{}{
@@ -213,14 +213,14 @@ func createTagbotUserWithValidBody(request *http.Request, body createUserRequest
 				"err":     err.Error(),
 			})
 		}
-		return 200, user
+		return http.StatusOK, user
 	} else {
 		logger.Error(err.Error(), nil)
 		errSplit := strings.Split(err.Error(), ":")
 		if len(errSplit) >= 1 && errSplit[0] == "Error 1062" {
-			return 409, errors.New("Account already exists.")
+			return http.StatusConflict, errors.New("Account already exists.")
 		} else {
-			return 500, errors.New("Failed to create user.")
+			return http.StatusInternalServerError, errors.New("Failed to create user.")
 		}
 	}
 }
@@ -245,15 +245,15 @@ func createViewerUser(request *http.Request, a routes.Arguments) (int, interface
 	tokenHash, err := getPasswordHash(token)
 	if err != nil {
 		logger.Error("Failed to create token hash.", err.Error())
-		return 500, errors.New("Failed to create token hash")
+		return http.StatusInternalServerError, errors.New("Failed to create token hash")
 	}
 	viewerUser, viewerUserPassword, err := CreateUserWithParent(ctx, tx, body.Email, currentUser)
 	if err != nil {
 		errSplit := strings.Split(err.Error(), ":")
 		if len(errSplit) >= 1 && errSplit[0] == "Error 1062" {
-			return 409, errors.New("Email already taken.")
+			return http.StatusConflict, errors.New("Email already taken.")
 		} else {
-			return 500, errors.New("Failed to create viewer user.")
+			return http.StatusInternalServerError, errors.New("Failed to create viewer user.")
 		}
 	}
 	response := createViewerUserResponseBody{
@@ -268,14 +268,14 @@ func createViewerUser(request *http.Request, a routes.Arguments) (int, interface
 	err = dbForgottenPassword.Insert(tx)
 	if err != nil {
 		logger.Error("Failed to insert viewer password token in database.", err.Error())
-		return 500, errors.New("Failed to create viewer password token")
+		return http.StatusInternalServerError, errors.New("Failed to create viewer password token")
 	}
 	mailSubject := "Your TrackIt viewer password"
 	mailBody := fmt.Sprintf("Please follow this link to create your password: https://re.trackit.io/reset/%d/%s.", dbForgottenPassword.ID, token)
 	err = mail.SendMail(viewerUser.Email, mailSubject, mailBody, request.Context())
 	if err != nil {
 		logger.Error("Failed to send viewer password email.", err.Error())
-		return 500, errors.New("Failed to send viewer password email")
+		return http.StatusInternalServerError, errors.New("Failed to send viewer password email")
 	}
 	return http.StatusOK, response
 }

--- a/users/login.go
+++ b/users/login.go
@@ -73,7 +73,7 @@ func logInWithValidBody(request *http.Request, body loginRequestBody, tx *sql.Tx
 		logger.Warning("Authentication failure.", struct {
 			Email string `json:"user"`
 		}{user.Email})
-		return 403, errors.New("The username or password is incorrect. Try again.")
+		return http.StatusForbidden, errors.New("The username or password is incorrect. Try again.")
 	}
 }
 
@@ -90,20 +90,20 @@ func logAuthenticatedUserIn(request *http.Request, user User) (int, interface{})
 			})
 		}
 		logger.Info("User logged in.", user)
-		return 200, loginResponseBody{
+		return http.StatusOK, loginResponseBody{
 			User:  user,
 			Token: token,
 		}
 	} else {
 		logger.Error("Failed to generate token.", err.Error())
-		return 500, errors.New("Failed to generate token.")
+		return http.StatusInternalServerError, errors.New("Failed to generate token.")
 	}
 }
 
 // TestToken tests a token's validity. For a valid token, it returns the user
 // the token belongs to.
 func me(request *http.Request, a routes.Arguments) (int, interface{}) {
-	return 200, a[AuthenticatedUser].(User)
+	return http.StatusOK, a[AuthenticatedUser].(User)
 }
 
 // updateLastSeen update the last seen datetime in the database

--- a/users/password.go
+++ b/users/password.go
@@ -110,7 +110,7 @@ func forgottenPasswordWithValidBody(request *http.Request, body forgottenPasswor
 			Email string `json:"user"`
 			Error string `json:"error"`
 		}{body.Email, err.Error()})
-		return 404, errors.New("User not found")
+		return http.StatusNotFound, errors.New("User not found")
 	}
 	return createForgottenPasswordEntry(request, body, tx, user)
 }
@@ -121,7 +121,7 @@ func createForgottenPasswordEntry(request *http.Request, body forgottenPasswordR
 	tokenHash, err := getPasswordHash(token)
 	if err != nil {
 		logger.Error("Failed to create token hash.", err.Error())
-		return 500, errors.New("Failed to create token hash")
+		return http.StatusInternalServerError, errors.New("Failed to create token hash")
 	}
 	dbForgottenPassword := models.ForgottenPassword{
 		UserID: user.Id,
@@ -131,16 +131,16 @@ func createForgottenPasswordEntry(request *http.Request, body forgottenPasswordR
 	err = dbForgottenPassword.Insert(tx)
 	if err != nil {
 		logger.Error("Failed to insert forgotten password token in database.", err.Error())
-		return 500, errors.New("Failed to create forgotten password token")
+		return http.StatusInternalServerError, errors.New("Failed to create forgotten password token")
 	}
 	mailSubject := "Reset your Trackit password"
 	mailBody := fmt.Sprintf("Please follow this link to recover your password: https://re.trackit.io/reset/%d/%s. This link is valid for an hour.", dbForgottenPassword.ID, token)
 	err = mail.SendMail(user.Email, mailSubject, mailBody, request.Context())
 	if err != nil {
 		logger.Error("Failed to send password recovery email.", err.Error())
-		return 500, errors.New("Failed to send password recovery email")
+		return http.StatusInternalServerError, errors.New("Failed to send password recovery email")
 	}
-	return 200, nil
+	return http.StatusOK, nil
 }
 
 // forgottenPassword handles users attempting to reset a forgotten password
@@ -159,7 +159,7 @@ func resetPasswordWithValidBody(request *http.Request, body resetPasswordRequest
 			Token string `json:"token"`
 			Error string `json:"error"`
 		}{body.Token, err.Error()})
-		return 404, errors.New("Reset token not found")
+		return http.StatusNotFound, errors.New("Reset token not found")
 	}
 	err = passwordMatchesHash(body.Token, forgottenPassword.Token)
 	delta := time.Now().Sub(forgottenPassword.Created)
@@ -168,7 +168,7 @@ func resetPasswordWithValidBody(request *http.Request, body resetPasswordRequest
 		logger.Warning("Invalid token", struct {
 			Token string `json:"token"`
 		}{body.Token})
-		return 400, errors.New("Invalid token")
+		return http.StatusBadRequest, errors.New("Invalid token")
 	}
 	return updatePasswordFromForgottenToken(request, body, tx, forgottenPassword)
 }
@@ -181,16 +181,16 @@ func updatePasswordFromForgottenToken(request *http.Request, body resetPasswordR
 			Token string `json:"token"`
 			Error string `json:"error"`
 		}{forgottenPassword.Token, err.Error()})
-		return 404, errors.New("Unable to retrieve user")
+		return http.StatusNotFound, errors.New("Unable to retrieve user")
 	}
 	err = user.UpdatePassword(tx, body.Password)
 	if err != nil {
 		logger.Warning("Unable to update user password", err.Error())
-		return 500, errors.New("Unable to update user")
+		return http.StatusInternalServerError, errors.New("Unable to update user")
 	}
 	err = forgottenPassword.Delete(tx)
 	if err != nil {
 		logger.Warning("Unable to delete forgotten password token", err.Error())
 	}
-	return 200, nil
+	return http.StatusOK, nil
 }

--- a/users/shared_account/invite.go
+++ b/users/shared_account/invite.go
@@ -181,7 +181,7 @@ func inviteUserAlreadyExist(ctx context.Context, tx *sql.Tx, body InviteUserRequ
 	logger := jsonlog.LoggerFromContextOrDefault(ctx)
 	isAlreadyShared, err := checkSharedAccount(ctx, tx, accountId, guestId)
 	if err != nil {
-		return 403, ErrorInviteUser
+		return http.StatusForbidden, ErrorInviteUser
 	} else if isAlreadyShared {
 		return http.StatusBadRequest, ErrorAlreadyShared
 	}
@@ -190,12 +190,12 @@ func inviteUserAlreadyExist(ctx context.Context, tx *sql.Tx, body InviteUserRequ
 		err = sendMailNotification(ctx, tx, body.Email, true, 0)
 		if err != nil {
 			logger.Error("Error occured while sending an email to an existing user.", err.Error())
-			return 403, ErrorInviteUser
+			return http.StatusForbidden, ErrorInviteUser
 		}
 		return http.StatusOK, sharedAccount
 	} else {
 		logger.Error("Error occured while adding account to an existing user.", err.Error())
-		return 403, ErrorInviteUser
+		return http.StatusForbidden, ErrorInviteUser
 	}
 }
 
@@ -207,12 +207,12 @@ func inviteNewUser(ctx context.Context, tx *sql.Tx, body InviteUserRequest, acco
 		err = sendMailNotification(ctx, tx, body.Email, false, newUserId)
 		if err != nil {
 			logger.Error("Error occured while sending an email to a new user.", err.Error())
-			return 403, ErrorInviteNewUser
+			return http.StatusForbidden, ErrorInviteNewUser
 		}
 		return http.StatusOK, newUser
 	} else {
 		logger.Error("Error occured while creating new account for a guest.", err.Error())
-		return 403, ErrorInviteNewUser
+		return http.StatusForbidden, ErrorInviteNewUser
 	}
 }
 
@@ -240,6 +240,6 @@ func InviteUserWithValidBody(request *http.Request, body InviteUserRequest, acco
 		}
 	} else {
 		logger.Error("Error occured while checking body elements.", err.Error())
-		return 403, ErrorInviteNewUser
+		return http.StatusForbidden, ErrorInviteNewUser
 	}
 }


### PR DESCRIPTION
Went through all the places in the code that use raw values for the `http.Status` enums and made them consistent